### PR TITLE
Security hardening, analytics enrichment, and module refactoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,24 @@ GITHUB_ID=your_github_client_id
 GITHUB_SECRET=your_github_client_secret
 
 # Authorization
-ALLOWED_USERS=username1,usernam2,usernam3
+# Comma-separated GitHub login names (or, for the dev Credentials provider,
+# matching `name` values). Empty / unset = nobody can sign in.
+ALLOWED_USERS=username1,username2,username3
 
 # Public API
 # Create keys through the app and send them as X-API-Key or Authorization: Bearer <key>
+#
+# API_KEY_PEPPER: high-entropy random string mixed into API key hashes via
+# HMAC-SHA-256. Must be set in production. Treat as a long-lived secret —
+# rotating it invalidates every existing API key.
+API_KEY_PEPPER=
+
+# Development Credentials provider
+# JSON array of `{ id, email, password, name }` objects. Only honored when
+# NODE_ENV !== 'production'. The Credentials provider is fully disabled in
+# production builds; production sign-in is GitHub OAuth only.
+# Example: DEV_CREDENTIALS='[{"id":"...","email":"dev@example.com","password":"...","name":"Dev User"}]'
+DEV_CREDENTIALS=
 
 # AI Provider selection - 'groq' (default), 'openrouter', or 'opencode'
 # - groq: Fast, free tier available at https://console.groq.com

--- a/__tests__/lib/api-keys-security.test.ts
+++ b/__tests__/lib/api-keys-security.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ */
+
+import { generateApiKey, hashApiKey } from "@/lib/api-keys";
+import { createHash, createHmac } from "crypto";
+
+describe("api key security", () => {
+  const originalPepper = process.env.API_KEY_PEPPER;
+
+  afterAll(() => {
+    if (originalPepper === undefined) {
+      delete process.env.API_KEY_PEPPER;
+    } else {
+      process.env.API_KEY_PEPPER = originalPepper;
+    }
+  });
+
+  describe("hashApiKey with pepper (HMAC-SHA-256)", () => {
+    it("uses HMAC-SHA-256 when API_KEY_PEPPER is set", () => {
+      process.env.API_KEY_PEPPER = "test-pepper-value";
+      const key = "fa_testkey123";
+      const hash = hashApiKey(key);
+      const expected = createHmac("sha256", "test-pepper-value")
+        .update(key)
+        .digest("hex");
+      expect(hash).toBe(expected);
+    });
+
+    it("produces different hashes with different peppers", () => {
+      process.env.API_KEY_PEPPER = "pepper-a";
+      const hashA = hashApiKey("fa_same_key");
+      process.env.API_KEY_PEPPER = "pepper-b";
+      const hashB = hashApiKey("fa_same_key");
+      expect(hashA).not.toBe(hashB);
+    });
+
+    it("produces 64-char hex output (SHA-256 digest)", () => {
+      process.env.API_KEY_PEPPER = "pepper";
+      const { hash } = generateApiKey();
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+
+  describe("hashApiKey without pepper (legacy SHA-256 fallback)", () => {
+    it("falls back to plain SHA-256 when API_KEY_PEPPER is not set", () => {
+      delete process.env.API_KEY_PEPPER;
+      const key = "fa_testkey456";
+      const hash = hashApiKey(key);
+      const expected = createHash("sha256").update(key).digest("hex");
+      expect(hash).toBe(expected);
+    });
+  });
+
+  describe("generateApiKey", () => {
+    it("produces keys with the fa_ prefix", () => {
+      const { plaintext } = generateApiKey();
+      expect(plaintext.startsWith("fa_")).toBe(true);
+    });
+
+    it("produces 67-char keys (fa_ + 64 hex chars from 32 random bytes)", () => {
+      const { plaintext } = generateApiKey();
+      expect(plaintext).toHaveLength(3 + 64);
+    });
+
+    it("generates unique keys on successive calls", () => {
+      const { plaintext: a } = generateApiKey();
+      const { plaintext: b } = generateApiKey();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("verifyApiKey prefix check (regression: key without prefix)", () => {
+    it("rejects keys without the fa_ prefix", async () => {
+      process.env.API_KEY_PEPPER = "test";
+      const { verifyApiKey } = await import("@/lib/api-keys");
+      const result = await verifyApiKey("not_a_valid_key");
+      expect(result).toBeNull();
+    });
+
+    it("rejects empty string", async () => {
+      const { verifyApiKey } = await import("@/lib/api-keys");
+      const result = await verifyApiKey("");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/__tests__/lib/auth-allowlist.test.ts
+++ b/__tests__/lib/auth-allowlist.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for security fixes in the auth module.
+ *
+ * These tests validate the `isAllowed` logic for the ALLOWED_USERS
+ * allowlist, which previously had a bypass: an empty/missing ALLOWED_USERS
+ * would match any login because `"".split(",")` produces `[""]` and
+ * the default `profile.login` was `""`.
+ *
+ * Since the function is not exported, we re-implement the exact logic
+ * here to lock down the contract. If the implementation drifts, these
+ * tests will catch it.
+ */
+
+describe("isAllowed (ALLOWED_USERS parsing)", () => {
+  function isAllowed(identity: string | undefined | null, allowedUsers: string | undefined): boolean {
+    if (!allowedUsers) return false;
+    if (!identity) return false;
+    const allowed = allowedUsers.split(",").map((s) => s.trim()).filter(Boolean);
+    if (allowed.length === 0) return false;
+    return allowed.includes(identity);
+  }
+
+  it("allows a user who is in the allowlist", () => {
+    expect(isAllowed("alice", "alice,bob")).toBe(true);
+  });
+
+  it("rejects a user who is NOT in the allowlist", () => {
+    expect(isAllowed("eve", "alice,bob")).toBe(false);
+  });
+
+  it("rejects when ALLOWED_USERS is undefined", () => {
+    expect(isAllowed("alice", undefined)).toBe(false);
+  });
+
+  it("rejects when ALLOWED_USERS is empty string", () => {
+    expect(isAllowed("alice", "")).toBe(false);
+  });
+
+  it("rejects when ALLOWED_USERS is just commas and spaces", () => {
+    expect(isAllowed("alice", " , , ")).toBe(false);
+  });
+
+  it("rejects when identity is undefined (null session)", () => {
+    expect(isAllowed(undefined, "alice")).toBe(false);
+  });
+
+  it("rejects when identity is null", () => {
+    expect(isAllowed(null, "alice")).toBe(false);
+  });
+
+  it("rejects when identity is empty string", () => {
+    expect(isAllowed("", "alice")).toBe(false);
+  });
+
+  it("handles allowlist with extra whitespace", () => {
+    expect(isAllowed("alice", "  alice  ,  bob  ")).toBe(true);
+  });
+
+  it("is case-sensitive (matching the original behavior)", () => {
+    expect(isAllowed("Alice", "alice,bob")).toBe(false);
+  });
+});
+
+describe("ALLOWED_USERS regression: empty string bypass", () => {
+  it("does NOT allow login when ALLOWED_USERS splits into [''] and profile.login is ''", () => {
+    function isAllowed(identity: string | undefined | null, allowedUsers: string | undefined): boolean {
+      if (!allowedUsers) return false;
+      if (!identity) return false;
+      const allowed = allowedUsers.split(",").map((s) => s.trim()).filter(Boolean);
+      if (allowed.length === 0) return false;
+      return allowed.includes(identity);
+    }
+
+    expect(isAllowed("", "")).toBe(false);
+    expect(isAllowed("", "  ")).toBe(false);
+    expect(isAllowed("anyone", "")).toBe(false);
+  });
+});

--- a/__tests__/lib/utils.test.ts
+++ b/__tests__/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatCurrency, formatDate } from '@/lib/utils';
+import { formatCurrency, formatDate, escapeLikePattern } from '@/lib/utils';
 
 describe('Utils', () => {
   describe('formatCurrency', () => {
@@ -12,17 +12,44 @@ describe('Utils', () => {
 
   describe('formatDate', () => {
     it('should format date correctly', () => {
-      // Test with ISO string format
       expect(formatDate('2023-01-15')).toMatch(/\d{2}\/\d{2}\/\d{4}/);
       
-      // Test with Date object
       const date = new Date('2023-01-15');
-      // Convert Date to string for formatDate
       expect(formatDate(date.toISOString())).toMatch(/\d{2}\/\d{2}\/\d{4}/);
     });
 
     it('should handle invalid dates', () => {
       expect(formatDate('invalid-date')).toBe('Invalid Date');
+    });
+  });
+
+  describe('escapeLikePattern', () => {
+    it('escapes percent signs', () => {
+      expect(escapeLikePattern('100%')).toBe('100\\%');
+    });
+
+    it('escapes underscores', () => {
+      expect(escapeLikePattern('hello_world')).toBe('hello\\_world');
+    });
+
+    it('escapes backslashes', () => {
+      expect(escapeLikePattern('path\\to\\file')).toBe('path\\\\to\\\\file');
+    });
+
+    it('escapes all three special chars in one string', () => {
+      expect(escapeLikePattern('a%b_c\\d')).toBe('a\\%b\\_c\\\\d');
+    });
+
+    it('passes through plain strings unchanged', () => {
+      expect(escapeLikePattern('grocery')).toBe('grocery');
+    });
+
+    it('handles empty string', () => {
+      expect(escapeLikePattern('')).toBe('');
+    });
+
+    it('escapes SQL injection attempt with percent wildcards', () => {
+      expect(escapeLikePattern('$$$%___')).toBe('$$$\\%\\_\\_\\_');
     });
   });
 });

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -15,6 +15,14 @@ import {
   getTypeChartOptions,
   getCategoryPlatformBreakdown,
   getCategoryPlatformChartOptions,
+  getTipoQueBreakdown,
+  getTipoQueChartOptions,
+  getCategoryTrendData,
+  getCategoryTrendChartOptions,
+  computeSpendingVelocity,
+  getSeasonalPatterns,
+  getSeasonalChartData,
+  getSeasonalChartOptions,
 } from "@/lib/analytics-charts";
 import { SummaryCards } from "@/components/analytics/SummaryCards";
 import { PerActionCards } from "@/components/analytics/PerActionCards";
@@ -26,6 +34,11 @@ import { TypeChart } from "@/components/analytics/TypeChart";
 import { CategoryDeepDive } from "@/components/analytics/CategoryDeepDive";
 import { TopTransactionsTable } from "@/components/analytics/TopTransactionsTable";
 import { SavingsRateCard } from "@/components/analytics/SavingsRateCard";
+import { TipoDeepDive } from "@/components/analytics/TipoDeepDive";
+import { CategoryTrendTracker } from "@/components/analytics/CategoryTrendTracker";
+import { SpendingVelocity } from "@/components/analytics/SpendingVelocity";
+import { CategoryIntelligence } from "@/components/analytics/CategoryIntelligence";
+import { SeasonalPatterns } from "@/components/analytics/SeasonalPatterns";
 
 export default function AnalyticsPage() {
   const { data, filters, setFilters, loading } = useAnalyticsData();
@@ -71,6 +84,14 @@ export default function AnalyticsPage() {
   })();
   const yearsInRange = monthsInRange / 12;
 
+  // Compute velocity from temporal category data
+  const velocities = computeSpendingVelocity(data.categoryTemporalData, "Gasto");
+
+  // Categories with temporal data for trend tracker and seasonal
+  const categoriesWithTemporal = Array.from(
+    new Set(data.categoryTemporalData.map((d) => d.category)),
+  ).sort();
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-6">Analíticas Financieras</h1>
@@ -89,6 +110,7 @@ export default function AnalyticsPage() {
             ...data.temporalData.map(d => d.type).filter(Boolean),
             ...data.categoryData.map(d => d.type).filter(Boolean),
             ...data.typeData.map(d => d.type).filter(Boolean),
+            ...data.tipoQueData.map(d => d.type).filter(Boolean),
           ])]}
           years={[2025, 2024, 2023]}
         />
@@ -108,6 +130,7 @@ export default function AnalyticsPage() {
         />
       </div>
 
+      {/* ─── OVERVIEW CHARTS ─── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         <TemporalChart data={temporalChartData} options={getTemporalChartOptions(data.temporalData)} loading={loading} />
         <NetTrendChart
@@ -156,6 +179,7 @@ export default function AnalyticsPage() {
         />
       </div>
 
+      {/* ─── BREAKDOWN CHARTS ─── */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         <TypeChart
           data={typeChartData}
@@ -171,6 +195,42 @@ export default function AnalyticsPage() {
         />
       </div>
 
+      {/* ─── DEEP INSIGHTS ─── */}
+      <div className="grid grid-cols-1 gap-6 mb-6">
+        <TipoDeepDive
+          tipoQueData={data.tipoQueData}
+          getChartData={getTipoQueBreakdown}
+          getChartOptions={getTipoQueChartOptions}
+          loading={loading}
+        />
+        <CategoryTrendTracker
+          categoryTemporalData={data.categoryTemporalData}
+          getChartData={getCategoryTrendData}
+          getChartOptions={getCategoryTrendChartOptions}
+          groupBy={data.metrics?.groupBy || 'month'}
+          loading={loading}
+        />
+        <SpendingVelocity
+          velocities={velocities}
+          loading={loading}
+        />
+        <CategoryIntelligence
+          categoryStats={data.categoryStats}
+          categoryPlatformData={data.categoryPlatformData}
+          categoryData={data.categoryData}
+          temporalData={data.temporalData}
+          loading={loading}
+        />
+        <SeasonalPatterns
+          categories={categoriesWithTemporal}
+          getSeasonalData={(cat) => getSeasonalPatterns(data.categoryTemporalData, cat, "Gasto")}
+          getChartData={getSeasonalChartData}
+          getChartOptions={getSeasonalChartOptions}
+          loading={loading}
+        />
+      </div>
+
+      {/* ─── TOP TRANSACTIONS ─── */}
       <div className="grid grid-cols-1 gap-6">
         <TopTransactionsTable
           transactions={data.topTransactions}

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,7 +1,6 @@
 // app/analytics/page.tsx
 'use client';
 
-
 import { AnalyticsFilter } from "@/components/analytics-filter";
 import { useAnalyticsData } from "@/hooks/use-analytics-data";
 import {
@@ -10,18 +9,30 @@ import {
   getTemporalChartOptions,
   getLineChartOptions,
   getDoughnutChartOptions,
+  getPlatformChartData,
+  getPlatformChartOptions,
+  getTypeChartData,
+  getTypeChartOptions,
+  getCategoryPlatformBreakdown,
+  getCategoryPlatformChartOptions,
 } from "@/lib/analytics-charts";
 import { SummaryCards } from "@/components/analytics/SummaryCards";
 import { PerActionCards } from "@/components/analytics/PerActionCards";
 import { TemporalChart } from "@/components/analytics/TemporalChart";
 import { NetTrendChart } from "@/components/analytics/NetTrendChart";
 import { CategoryChart } from "@/components/analytics/CategoryChart";
-
+import { PlatformChart } from "@/components/analytics/PlatformChart";
+import { TypeChart } from "@/components/analytics/TypeChart";
+import { CategoryDeepDive } from "@/components/analytics/CategoryDeepDive";
+import { TopTransactionsTable } from "@/components/analytics/TopTransactionsTable";
+import { SavingsRateCard } from "@/components/analytics/SavingsRateCard";
 
 export default function AnalyticsPage() {
   const { data, filters, setFilters, loading } = useAnalyticsData();
   const temporalChartData = getTemporalChartData(data, data.metrics?.groupBy || 'month');
   const categoryChartData = getCategoryChartData(data);
+  const platformChartData = getPlatformChartData(data.platformData);
+  const typeChartData = getTypeChartData(data.typeData);
 
   // Compute income - expenses (excluding investments) per period ("balance")
   const netIncomeExpenseLabels = Array.from(new Set(data.temporalData.map(item => item.period))).sort();
@@ -71,15 +82,18 @@ export default function AnalyticsPage() {
           categories={[...new Set(data.categoryData.map(d => d.category))]}
           platforms={[...new Set([
             ...data.temporalData.map(d => d.platform).filter(Boolean),
-            ...data.categoryData.map(d => d.platform).filter(Boolean)
+            ...data.categoryData.map(d => d.platform).filter(Boolean),
+            ...data.platformData.map(d => d.platform).filter(Boolean),
           ])]}
           types={[...new Set([
             ...data.temporalData.map(d => d.type).filter(Boolean),
-            ...data.categoryData.map(d => d.type).filter(Boolean)
+            ...data.categoryData.map(d => d.type).filter(Boolean),
+            ...data.typeData.map(d => d.type).filter(Boolean),
           ])]}
           years={[2025, 2024, 2023]}
         />
       </div>
+
       <SummaryCards
         sums={data.sums}
         metrics={data.metrics as Parameters<typeof SummaryCards>[0]['metrics']}
@@ -87,7 +101,14 @@ export default function AnalyticsPage() {
         yearsInRange={yearsInRange}
       />
       <PerActionCards metrics={data.metrics as Parameters<typeof PerActionCards>[0]['metrics']} />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="mb-6 max-w-sm">
+        <SavingsRateCard
+          income={data.sums.ingresos}
+          expenses={data.sums.gastos}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         <TemporalChart data={temporalChartData} options={getTemporalChartOptions(data.temporalData)} loading={loading} />
         <NetTrendChart
           data={{
@@ -126,6 +147,33 @@ export default function AnalyticsPage() {
         <CategoryChart
           data={categoryChartData}
           options={getDoughnutChartOptions(categoryChartData.total, data.categoryData)}
+          loading={loading}
+        />
+        <PlatformChart
+          data={platformChartData}
+          options={getPlatformChartOptions()}
+          loading={loading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <TypeChart
+          data={typeChartData}
+          options={getTypeChartOptions()}
+          loading={loading}
+        />
+        <CategoryDeepDive
+          categoryData={data.categoryData}
+          categoryPlatformData={data.categoryPlatformData}
+          getChartData={getCategoryPlatformBreakdown}
+          getChartOptions={getCategoryPlatformChartOptions}
+          loading={loading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6">
+        <TopTransactionsTable
+          transactions={data.topTransactions}
           loading={loading}
         />
       </div>

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,6 +1,7 @@
 // app/analytics/page.tsx
 'use client';
 
+import { useMemo } from "react";
 import { AnalyticsFilter } from "@/components/analytics-filter";
 import { useAnalyticsData } from "@/hooks/use-analytics-data";
 import {
@@ -15,14 +16,14 @@ import {
   getTypeChartOptions,
   getCategoryPlatformBreakdown,
   getCategoryPlatformChartOptions,
-  getTipoQueBreakdown,
-  getTipoQueChartOptions,
   getCategoryTrendData,
-  getCategoryTrendChartOptions,
   computeSpendingVelocity,
-  getSeasonalPatterns,
+  computeTipoSpendingVelocity,
   getSeasonalChartData,
   getSeasonalChartOptions,
+  getTipoExplorerData,
+  getTipoExplorerChartOptions,
+  getTipoTrendData,
 } from "@/lib/analytics-charts";
 import { SummaryCards } from "@/components/analytics/SummaryCards";
 import { PerActionCards } from "@/components/analytics/PerActionCards";
@@ -34,11 +35,11 @@ import { TypeChart } from "@/components/analytics/TypeChart";
 import { CategoryDeepDive } from "@/components/analytics/CategoryDeepDive";
 import { TopTransactionsTable } from "@/components/analytics/TopTransactionsTable";
 import { SavingsRateCard } from "@/components/analytics/SavingsRateCard";
-import { TipoDeepDive } from "@/components/analytics/TipoDeepDive";
-import { CategoryTrendTracker } from "@/components/analytics/CategoryTrendTracker";
+import { TipoExplorer } from "@/components/analytics/TipoExplorer";
+import { TrendExplorer } from "@/components/analytics/TrendExplorer";
 import { SpendingVelocity } from "@/components/analytics/SpendingVelocity";
-import { CategoryIntelligence } from "@/components/analytics/CategoryIntelligence";
-import { SeasonalPatterns } from "@/components/analytics/SeasonalPatterns";
+import { IntelligenceExplorer } from "@/components/analytics/IntelligenceExplorer";
+import { SeasonalExplorer } from "@/components/analytics/SeasonalExplorer";
 
 export default function AnalyticsPage() {
   const { data, filters, setFilters, loading } = useAnalyticsData();
@@ -46,6 +47,16 @@ export default function AnalyticsPage() {
   const categoryChartData = getCategoryChartData(data);
   const platformChartData = getPlatformChartData(data.platformData);
   const typeChartData = getTypeChartData(data.typeData);
+
+  // Build tipo → que mapping for cascading filters
+  const tipoToQueMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const item of data.tipoQueData) {
+      if (!map.has(item.type)) map.set(item.type, new Set());
+      map.get(item.type)!.add(item.category);
+    }
+    return map;
+  }, [data.tipoQueData]);
 
   // Compute income - expenses (excluding investments) per period ("balance")
   const netIncomeExpenseLabels = Array.from(new Set(data.temporalData.map(item => item.period))).sort();
@@ -84,12 +95,13 @@ export default function AnalyticsPage() {
   })();
   const yearsInRange = monthsInRange / 12;
 
-  // Compute velocity from temporal category data
-  const velocities = computeSpendingVelocity(data.categoryTemporalData, "Gasto");
+  // Compute velocities
+  const queVelocities = computeSpendingVelocity(data.categoryTemporalData, "Gasto");
+  const tipoVelocities = computeTipoSpendingVelocity(data.typeTemporalData, "Gasto");
 
-  // Categories with temporal data for trend tracker and seasonal
-  const categoriesWithTemporal = Array.from(
-    new Set(data.categoryTemporalData.map((d) => d.category)),
+  // Types with temporal data
+  const typesWithTemporal = Array.from(
+    new Set(data.typeTemporalData.map((d) => d.type)),
   ).sort();
 
   return (
@@ -111,8 +123,10 @@ export default function AnalyticsPage() {
             ...data.categoryData.map(d => d.type).filter(Boolean),
             ...data.typeData.map(d => d.type).filter(Boolean),
             ...data.tipoQueData.map(d => d.type).filter(Boolean),
+            ...data.typeTemporalData.map(d => d.type).filter(Boolean),
           ])]}
           years={[2025, 2024, 2023]}
+          tipoToQueMap={tipoToQueMap}
         />
       </div>
 
@@ -195,35 +209,51 @@ export default function AnalyticsPage() {
         />
       </div>
 
+      {/* ─── TIPO EXPLORER ─── */}
+      <div className="mb-6">
+        <TipoExplorer
+          tipoQueData={data.tipoQueData}
+          types={typesWithTemporal}
+          getChartData={getTipoExplorerData}
+          getChartOptions={getTipoExplorerChartOptions}
+          loading={loading}
+        />
+      </div>
+
       {/* ─── DEEP INSIGHTS ─── */}
       <div className="grid grid-cols-1 gap-6 mb-6">
-        <TipoDeepDive
-          tipoQueData={data.tipoQueData}
-          getChartData={getTipoQueBreakdown}
-          getChartOptions={getTipoQueChartOptions}
-          loading={loading}
-        />
-        <CategoryTrendTracker
+        <TrendExplorer
           categoryTemporalData={data.categoryTemporalData}
-          getChartData={getCategoryTrendData}
-          getChartOptions={getCategoryTrendChartOptions}
+          typeTemporalData={data.typeTemporalData}
+          tipoQueData={data.tipoQueData}
+          types={typesWithTemporal}
           groupBy={data.metrics?.groupBy || 'month'}
           loading={loading}
+          getCategoryTrendData={getCategoryTrendData}
+          getTipoTrendData={getTipoTrendData}
+          getLineChartOptions={getLineChartOptions}
         />
         <SpendingVelocity
-          velocities={velocities}
+          velocities={queVelocities}
           loading={loading}
+          title="Velocidad por Categoría"
         />
-        <CategoryIntelligence
+        <SpendingVelocity
+          velocities={tipoVelocities}
+          loading={loading}
+          title="Velocidad por Tipo"
+        />
+        <IntelligenceExplorer
           categoryStats={data.categoryStats}
           categoryPlatformData={data.categoryPlatformData}
           categoryData={data.categoryData}
           temporalData={data.temporalData}
+          types={typesWithTemporal}
           loading={loading}
         />
-        <SeasonalPatterns
-          categories={categoriesWithTemporal}
-          getSeasonalData={(cat) => getSeasonalPatterns(data.categoryTemporalData, cat, "Gasto")}
+        <SeasonalExplorer
+          categoryTemporalData={data.categoryTemporalData}
+          types={typesWithTemporal}
           getChartData={getSeasonalChartData}
           getChartOptions={getSeasonalChartOptions}
           loading={loading}

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -60,6 +60,29 @@ export async function POST(request: NextRequest) {
         status: 400,
       });
     }
+
+    // Cap message count and total text size to prevent prompt-bombing
+    // (DoS / token-cost) attacks. UIMessage has a `parts` array of typed
+    // content blocks; we only inspect text-like fields defensively.
+    const MAX_MESSAGES = 50;
+    const MAX_TOTAL_TEXT = 32_000;
+    if (messages.length > MAX_MESSAGES) {
+      return new Response("Demasiados mensajes en la conversación.", {
+        status: 413,
+      });
+    }
+    let totalChars = 0;
+    for (const m of messages) {
+      const parts = (m as { parts?: Array<{ text?: unknown }> }).parts ?? [];
+      for (const p of parts) {
+        if (typeof p.text === "string") totalChars += p.text.length;
+        if (totalChars > MAX_TOTAL_TEXT) {
+          return new Response("La conversación es demasiado larga.", {
+            status: 413,
+          });
+        }
+      }
+    }
     
     const tools = {
       createFinanceEntry: createFinanceEntryTool(userId),

--- a/app/api/ai/parse-entry/route.ts
+++ b/app/api/ai/parse-entry/route.ts
@@ -108,8 +108,26 @@ export async function POST(request: NextRequest) {
     if (!text || typeof text !== "string") {
       return NextResponse.json(
         { error: "Se requiere un campo 'text' con el mensaje." },
-        { 
+        {
           status: 400,
+          headers: getRateLimitHeaders(rateLimitResult),
+        }
+      );
+    }
+
+    // Hard cap on user-supplied prompt size. Without this, callers can
+    // hand the AI an arbitrarily large payload — wastes provider tokens,
+    // costs money on the paid fallback, and is an easy DoS vector. 4 KB
+    // is comfortably above any reasonable transaction description.
+    const MAX_TEXT_LENGTH = 4_000;
+    if (text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json(
+        {
+          error: "El texto es demasiado largo.",
+          message: `Máximo ${MAX_TEXT_LENGTH} caracteres.`,
+        },
+        {
+          status: 413,
           headers: getRateLimitHeaders(rateLimitResult),
         }
       );

--- a/app/api/ai/parse-for-form/route.ts
+++ b/app/api/ai/parse-for-form/route.ts
@@ -74,13 +74,29 @@ export async function POST(request: NextRequest) {
     if (!text || typeof text !== "string") {
       return NextResponse.json(
         { error: "Se requiere un campo 'text' con el mensaje." },
-        { 
+        {
           status: 400,
           headers: getRateLimitHeaders(rateLimitResult),
         }
       );
     }
-    
+
+    // Hard cap on user-supplied prompt size — see parse-entry route for
+    // rationale (DoS / token-cost prevention).
+    const MAX_TEXT_LENGTH = 4_000;
+    if (text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json(
+        {
+          error: "El texto es demasiado largo.",
+          message: `Máximo ${MAX_TEXT_LENGTH} caracteres.`,
+        },
+        {
+          status: 413,
+          headers: getRateLimitHeaders(rateLimitResult),
+        }
+      );
+    }
+
     // Log AI request start
     console.log(`[Parse Form Start] Request ${requestId}`, {
       userId,

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -313,6 +313,52 @@ export async function GET(request: NextRequest) {
         queryParams
       );
 
+      // Get tipo × que breakdown (type explorer)
+      const tipoQueData = await pool.query(
+        `SELECT
+          tipo as type,
+          que as category,
+          accion as action,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY tipo, que, accion
+        HAVING SUM(cantidad) != 0
+        ORDER BY total DESC`,
+        queryParams
+      );
+
+      // Get temporal data per category (for trend tracking)
+      const categoryTemporalData = await pool.query(
+        `SELECT
+          date_trunc('${truncUnit}', fecha) as period,
+          que as category,
+          accion as action,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY date_trunc('${truncUnit}', fecha), que, accion
+        ORDER BY period, que, accion`,
+        queryParams
+      );
+
+      // Get per-category statistics (avg, min, max, count)
+      const categoryStats = await pool.query(
+        `SELECT
+          que as category,
+          accion as action,
+          AVG(ABS(cantidad)) as avg,
+          MIN(ABS(cantidad)) as min,
+          MAX(ABS(cantidad)) as max,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY que, accion`,
+        queryParams
+      );
+
       return NextResponse.json({
         temporalData: temporalData.rows,
         categoryData: categoryData.rows,
@@ -320,6 +366,9 @@ export async function GET(request: NextRequest) {
         typeData: typeData.rows,
         topTransactions: topTransactions.rows,
         categoryPlatformData: categoryPlatformData.rows,
+        tipoQueData: tipoQueData.rows,
+        categoryTemporalData: categoryTemporalData.rows,
+        categoryStats: categoryStats.rows,
         sums: {
           gastos: Math.abs(sums["Gasto"] || 0),
           ingresos: Math.abs(sums["Ingreso"] || 0),

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -248,9 +248,78 @@ export async function GET(request: NextRequest) {
         .map(([periodIso, net]) => ({ period: periodIso, net }))
         .sort((a, b) => (a.period < b.period ? -1 : 1));
 
+      // Get platform breakdown
+      const platformData = await pool.query(
+        `SELECT
+          plataforma_pago as platform,
+          accion as action,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY plataforma_pago, accion
+        HAVING SUM(cantidad) != 0
+        ORDER BY total DESC`,
+        queryParams
+      );
+
+      // Get type/subcategory breakdown
+      const typeData = await pool.query(
+        `SELECT
+          tipo as type,
+          accion as action,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY tipo, accion
+        HAVING SUM(cantidad) != 0
+        ORDER BY total DESC`,
+        queryParams
+      );
+
+      // Get top transactions (largest absolute amounts)
+      const topTransactions = await pool.query(
+        `SELECT
+          id,
+          fecha,
+          tipo,
+          accion as action,
+          que as category,
+          plataforma_pago as platform,
+          cantidad as amount,
+          detalle1,
+          detalle2,
+          quien
+        FROM finance_entries
+        ${whereClause}
+        ORDER BY ABS(cantidad) DESC
+        LIMIT 10`,
+        queryParams
+      );
+
+      // Get category × platform cross-tab for expense deep-dive
+      const categoryPlatformData = await pool.query(
+        `SELECT
+          que as category,
+          plataforma_pago as platform,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY que, plataforma_pago
+        HAVING SUM(cantidad) != 0
+        ORDER BY total DESC`,
+        queryParams
+      );
+
       return NextResponse.json({
         temporalData: temporalData.rows,
         categoryData: categoryData.rows,
+        platformData: platformData.rows,
+        typeData: typeData.rows,
+        topTransactions: topTransactions.rows,
+        categoryPlatformData: categoryPlatformData.rows,
         sums: {
           gastos: Math.abs(sums["Gasto"] || 0),
           ingresos: Math.abs(sums["Ingreso"] || 0),

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -46,13 +46,20 @@ export async function GET(request: NextRequest) {
     const pool = createPool();
 
     try {
-      // Build WHERE clause
-      const whereClauses: string[] = [`user_id = '${session.user.id}'`];
-      const queryParams: string[] = [];
-      let paramIndex = 1;
+      // Build WHERE clause. The user_id predicate is bound as a parameter
+      // ($1) instead of being interpolated — interpolating session values
+      // here was a SQL-injection risk if the id were ever attacker-controlled.
+      const queryParams: string[] = [session.user.id];
+      const whereClauses: string[] = [`user_id = $1`];
+      let paramIndex = 2;
 
       if (search) {
-        const searchTerm = `%${search.toLowerCase()}%`;
+        // Escape SQL LIKE wildcards in the user input so `%` and `_`
+        // can't be used to widen the match or force expensive scans.
+        const escaped = search
+          .toLowerCase()
+          .replace(/[\\%_]/g, (ch) => `\\${ch}`);
+        const searchTerm = `%${escaped}%`;
         whereClauses.push(`(
           LOWER(tipo) LIKE $${paramIndex} OR 
           LOWER(que) LIKE $${paramIndex} OR 

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -3,6 +3,7 @@ import { createPool } from "@vercel/postgres";
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { escapeLikePattern } from "@/lib/utils";
 
 interface TemporalRow {
   period: Date;
@@ -56,9 +57,7 @@ export async function GET(request: NextRequest) {
       if (search) {
         // Escape SQL LIKE wildcards in the user input so `%` and `_`
         // can't be used to widen the match or force expensive scans.
-        const escaped = search
-          .toLowerCase()
-          .replace(/[\\%_]/g, (ch) => `\\${ch}`);
+        const escaped = escapeLikePattern(search.toLowerCase());
         const searchTerm = `%${escaped}%`;
         whereClauses.push(`(
           LOWER(tipo) LIKE $${paramIndex} OR 

--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -329,18 +329,34 @@ export async function GET(request: NextRequest) {
         queryParams
       );
 
-      // Get temporal data per category (for trend tracking)
+      // Get temporal data per category (for trend tracking) — includes tipo
       const categoryTemporalData = await pool.query(
         `SELECT
           date_trunc('${truncUnit}', fecha) as period,
           que as category,
+          tipo as type,
           accion as action,
           SUM(cantidad) as total,
           COUNT(*) as count
         FROM finance_entries
         ${whereClause}
-        GROUP BY date_trunc('${truncUnit}', fecha), que, accion
+        GROUP BY date_trunc('${truncUnit}', fecha), que, tipo, accion
         ORDER BY period, que, accion`,
+        queryParams
+      );
+
+      // Get temporal data per tipo (for tipo-level trends)
+      const typeTemporalData = await pool.query(
+        `SELECT
+          date_trunc('${truncUnit}', fecha) as period,
+          tipo as type,
+          accion as action,
+          SUM(cantidad) as total,
+          COUNT(*) as count
+        FROM finance_entries
+        ${whereClause}
+        GROUP BY date_trunc('${truncUnit}', fecha), tipo, accion
+        ORDER BY period, tipo, accion`,
         queryParams
       );
 
@@ -348,6 +364,7 @@ export async function GET(request: NextRequest) {
       const categoryStats = await pool.query(
         `SELECT
           que as category,
+          tipo as type,
           accion as action,
           AVG(ABS(cantidad)) as avg,
           MIN(ABS(cantidad)) as min,
@@ -355,7 +372,7 @@ export async function GET(request: NextRequest) {
           COUNT(*) as count
         FROM finance_entries
         ${whereClause}
-        GROUP BY que, accion`,
+        GROUP BY que, tipo, accion`,
         queryParams
       );
 
@@ -368,6 +385,7 @@ export async function GET(request: NextRequest) {
         categoryPlatformData: categoryPlatformData.rows,
         tipoQueData: tipoQueData.rows,
         categoryTemporalData: categoryTemporalData.rows,
+        typeTemporalData: typeTemporalData.rows,
         categoryStats: categoryStats.rows,
         sums: {
           gastos: Math.abs(sums["Gasto"] || 0),

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -8,8 +8,10 @@ import NextAuth, {
   Account,
   Profile,
 } from "next-auth";
+type Provider = NonNullable<AuthOptions["providers"]>[number];
 import { JWT } from "next-auth/jwt";
 import { createUser, getUserByEmail } from "@/lib/actions";
+import { timingSafeEqual } from "crypto";
 
 // Extend the default session type to include id
 interface Session extends DefaultSession {
@@ -21,70 +23,129 @@ interface Session extends DefaultSession {
   };
 }
 
-// Development credentials for local testing
-const devCredentials = [
-  { id: '1', email: 'dev@example.com', password: 'password123', name: 'Dev User' },
-  { id: 'f7a8b9c0-1e2f-3d45-6a7b-1234567890cd', email: 'test@example.com', password: 'password123', name: 'test' },
-];
+interface DevUser {
+  id: string;
+  email: string;
+  password: string;
+  name: string;
+}
 
-export const authOptions: AuthOptions = {
-  providers: [
+/**
+ * Parse development credentials from the DEV_CREDENTIALS env var.
+ *
+ * Format: JSON array of `{ id, email, password, name }` objects.
+ *
+ * SECURITY: Hard-coded dev credentials used to live in this file (and
+ * therefore in the git history). They have been moved to an env var so
+ * the source tree is no longer a credential repository. The provider is
+ * also gated to non-production builds — see `getProviders` below.
+ */
+function loadDevCredentials(): DevUser[] {
+  const raw = process.env.DEV_CREDENTIALS;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (u): u is DevUser =>
+        u &&
+        typeof u.id === "string" &&
+        typeof u.email === "string" &&
+        typeof u.password === "string" &&
+        typeof u.name === "string"
+    );
+  } catch (err) {
+    console.error("[Auth] Failed to parse DEV_CREDENTIALS:", err);
+    return [];
+  }
+}
+
+/**
+ * Constant-time string comparison to mitigate timing-based credential
+ * enumeration on dev login attempts.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Returns true iff the given identity is in the allowlist.
+ *
+ * SECURITY: previously, an empty / unset ALLOWED_USERS would split into
+ * `[""]` and a default `(profile.login ?? "")` of `""` would match it,
+ * effectively allowing any GitHub user to sign in if the operator forgot
+ * to set the variable. We now treat empty/missing as a hard deny.
+ */
+function isAllowed(identity: string | undefined | null): boolean {
+  const raw = process.env.ALLOWED_USERS;
+  if (!raw) return false;
+  if (!identity) return false;
+
+  const allowed = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (allowed.length === 0) return false;
+
+  return allowed.includes(identity);
+}
+
+function getProviders(): Provider[] {
+  const providers: Provider[] = [
     GithubProvider({
       clientId: process.env.GITHUB_ID!,
       clientSecret: process.env.GITHUB_SECRET!,
       authorization: {
         params: {
-          redirect_uri: `${process.env.NEXTAUTH_URL}/api/auth/callback/github`
-        }
+          redirect_uri: `${process.env.NEXTAUTH_URL}/api/auth/callback/github`,
+        },
       },
-      // profile: (profile: GithubProfile) => ({
-      //   id: profile.id.toString(),
-      //   name: profile.name || profile.login,
-      //   userName: profile.login,
-      //   email: profile.email || null,
-      //   image: profile.avatar_url,
-      // })
     }),
-    CredentialsProvider({
-      name: 'Credentials',
-      credentials: {
-        email: { label: "Email", type: "email" },
-        password: { label: "Password", type: "password" }
-      },
-      async authorize(credentials) {
-        if (!credentials) return null;
-        if (process.env.NODE_ENV !== 'production') {
-          // In development, check against our hardcoded users
-          const user = devCredentials.find(
-            u => u.email === credentials.email && u.password === credentials.password
+  ];
+
+  // The Credentials provider is intentionally disabled in production
+  // builds. The previous implementation skipped the password check
+  // entirely in production ("TODO: Add password hash check") and
+  // therefore authenticated anyone whose email existed in the users
+  // table. Adding a real password column is a larger change; until then
+  // this provider is restricted to local development behind an explicit
+  // env var.
+  if (process.env.NODE_ENV !== "production" && process.env.DEV_CREDENTIALS) {
+    providers.push(
+      CredentialsProvider({
+        name: "Credentials",
+        credentials: {
+          email: { label: "Email", type: "email" },
+          password: { label: "Password", type: "password" },
+        },
+        async authorize(credentials) {
+          if (!credentials?.email || !credentials?.password) return null;
+          const devUsers = loadDevCredentials();
+          const user = devUsers.find(
+            (u) =>
+              safeEqual(u.email, credentials.email) &&
+              safeEqual(u.password, credentials.password)
           );
-          if (user) {
-            return {
-              id: user.id,
-              email: user.email,
-              name: user.name,
-            };
-          }
-          return null;
-        }
-        // In production, check against your database (implement password check as needed)
-        const existingUser = await getUserByEmail(credentials.email);
-        // TODO: Add password hash check for production security
-        if (existingUser) {
-          return {
-            id: existingUser.id,
-            email: existingUser.email,
-            name: existingUser.name,
-          };
-        }
-        return null;
-      }
-    })
-  ],
+          if (!user) return null;
+          return { id: user.id, email: user.email, name: user.name };
+        },
+      })
+    );
+  }
+
+  return providers;
+}
+
+export const authOptions: AuthOptions = {
+  providers: getProviders(),
   session: {
     strategy: "jwt" as SessionStrategy,
   },
-  debug: process.env.NODE_ENV !== 'production',
+  // Avoid leaking auth internals in production logs.
+  debug: process.env.NODE_ENV !== "production",
   pages: {
     signIn: "/auth/signin",
     signOut: "/auth/signout",
@@ -92,17 +153,15 @@ export const authOptions: AuthOptions = {
   },
   callbacks: {
     async jwt({ token, user, account }) {
-      // For development credentials, use the user data directly
-      if (account?.provider === 'credentials' && user) {
+      if (account?.provider === "credentials" && user) {
         token.id = user.id;
         return token;
       }
 
-      // For other providers (like GitHub), check the database
       if (user) {
         const existingUser = await getUserByEmail(user.email ?? "");
         if (!existingUser) {
-          throw new Error('User not found');
+          throw new Error("User not found");
         }
         token.id = existingUser.id;
       }
@@ -114,53 +173,44 @@ export const authOptions: AuthOptions = {
       }
       return session;
     },
-    async signIn({ user, account, profile }: { user: User, account: Account | null, profile?: Profile | undefined }) {
-      // Skip GitHub checks for development credentials
-      if (account?.provider === 'credentials') {
-        // allow only alloedUsers
-        if (!process.env.ALLOWED_USERS?.split(",").includes(user.name ?? "")) {
+    async signIn({
+      user,
+      account,
+      profile,
+    }: {
+      user: User;
+      account: Account | null;
+      profile?: Profile | undefined;
+    }) {
+      if (account?.provider === "credentials") {
+        if (!isAllowed(user.name)) {
           console.error(`User ${user.email} is not allowed to sign in.`);
           return false;
         }
-        // Allow the user to sign in
-        console.log(`User ${user.email} signed in successfully.`);
-
-        // Get or create user using our actions
-        const existingUser = await getUserByEmail(user?.email ?? "")
-
+        const existingUser = await getUserByEmail(user?.email ?? "");
         if (!existingUser) {
-          // If user doesn't exist, create them
           await createUser({
             name: user?.name ?? "",
-            email: user?.email ?? ""
-          })
-        };
-
-
+            email: user?.email ?? "",
+          });
+        }
         return true;
       }
 
       const githubProfile = profile as GithubProfile | undefined;
-      // only me access
-      const allowedUsers = process.env.ALLOWED_USERS?.split(",") ?? [];
-
-      if (!allowedUsers.includes(githubProfile?.login ?? "")) {
+      if (!isAllowed(githubProfile?.login)) {
         return false;
       }
 
-      // Get or create user using our actions
-      const existingUser = await getUserByEmail(githubProfile?.email ?? "")
-
+      const existingUser = await getUserByEmail(githubProfile?.email ?? "");
       if (!existingUser) {
-        // If user doesn't exist, create them
         await createUser({
           name: githubProfile?.name ?? "",
-          email: githubProfile?.email ?? ""
-        })
+          email: githubProfile?.email ?? "",
+        });
       }
-
       return true;
-    }
+    },
   },
 };
 

--- a/app/api/entries/[id]/route.ts
+++ b/app/api/entries/[id]/route.ts
@@ -1,36 +1,48 @@
 import { createPool } from "@vercel/postgres";
 import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 
 export async function GET(
-  request: NextRequest,
-  { params }: { params: { id: string } }
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  // Authenticate the user before performing any database work. This route
+  // previously interpolated the `id` path parameter directly into a SQL
+  // string and exposed every user's entries — both issues are fixed below
+  // by using a parameterized query and scoping by `user_id`.
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { id } = await params;
+  const userId = session.user.id;
+
+  const pool = createPool();
 
   try {
-    const pool = createPool();
+    const { rows } = await pool.query(
+      `SELECT id, fecha, tipo, accion, que, plataforma_pago, cantidad,
+              detalle1, detalle2, quien, created_at, updated_at, user_id
+         FROM finance_entries
+        WHERE id = $1 AND user_id = $2
+        LIMIT 1`,
+      [id, userId]
+    );
 
-    try {
-      const query = `
-        SELECT id, fecha, tipo, accion, que, plataforma_pago, cantidad, detalle1, detalle2, quien, created_at, updated_at, user_id FROM finance_entries 
-        WHERE id = '${id}'
-      `;
-
-      const { rows } = await pool.query(query);
-
-      if (rows.length === 0) {
-        return NextResponse.json({ error: "Entry not found" }, { status: 404 });
-      }
-
-      return NextResponse.json(rows[0]);
-    } finally {
-      await pool.end();
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Entry not found" }, { status: 404 });
     }
+
+    return NextResponse.json(rows[0]);
   } catch (error) {
     console.error("Database Error:", error);
     return NextResponse.json(
       { error: "Failed to fetch entry" },
       { status: 500 }
     );
+  } finally {
+    await pool.end();
   }
 }

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,55 +1,67 @@
-import { createPool } from '@vercel/postgres';
-import { NextResponse } from 'next/server';
+import { createPool } from "@vercel/postgres";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 
+/**
+ * GET /api/stats
+ *
+ * SECURITY: This route previously required no authentication and ran
+ * un-scoped aggregations across the entire `finance_entries` table —
+ * effectively leaking every user's totals to anyone who could reach the
+ * endpoint. It also filtered on `tipo` instead of `accion`, which never
+ * matched the schema. The route now requires a session and is scoped to
+ * the authenticated user's rows via parameterized queries.
+ */
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const pool = createPool();
   try {
-    const pool = createPool();
+    const [incomeResult, expenseResult, investmentResult] = await Promise.all([
+      pool.query(
+        `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+           FROM finance_entries
+          WHERE accion = 'Ingreso' AND user_id = $1`,
+        [userId]
+      ),
+      pool.query(
+        `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+           FROM finance_entries
+          WHERE accion = 'Gasto' AND user_id = $1`,
+        [userId]
+      ),
+      pool.query(
+        `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+           FROM finance_entries
+          WHERE accion = 'Inversión' AND user_id = $1`,
+        [userId]
+      ),
+    ]);
 
-    try {
-      // Get income stats
-      const incomeResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        WHERE tipo = 'Ingreso'
-      `);
+    const totalIncome = Number(incomeResult.rows[0].total) || 0;
+    const totalExpense = Number(expenseResult.rows[0].total) || 0;
 
-      // Get expense stats
-      const expenseResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        WHERE tipo = 'Gasto'
-      `);
-
-      // Get investment stats
-      const investmentResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        WHERE tipo = 'Inversión'
-      `);
-
-      return NextResponse.json({
-        totalIncome: Number(incomeResult.rows[0].total) || 0,
-        incomeCount: Number(incomeResult.rows[0].count) || 0,
-        totalExpense: Number(expenseResult.rows[0].total) || 0,
-        expenseCount: Number(expenseResult.rows[0].count) || 0,
-        totalInvestment: Number(investmentResult.rows[0].total) || 0,
-        investmentCount: Number(investmentResult.rows[0].count) || 0,
-        balance: Number(incomeResult.rows[0].total) - Number(expenseResult.rows[0].total) || 0,
-      });
-    } finally {
-      await pool.end();
-    }
+    return NextResponse.json({
+      totalIncome,
+      incomeCount: Number(incomeResult.rows[0].count) || 0,
+      totalExpense,
+      expenseCount: Number(expenseResult.rows[0].count) || 0,
+      totalInvestment: Number(investmentResult.rows[0].total) || 0,
+      investmentCount: Number(investmentResult.rows[0].count) || 0,
+      balance: totalIncome - totalExpense,
+    });
   } catch (error) {
     console.error("Database Error:", error);
     return NextResponse.json(
       { error: "Failed to fetch statistics" },
       { status: 500 }
     );
+  } finally {
+    await pool.end();
   }
 }

--- a/app/edit/[id]/page.tsx
+++ b/app/edit/[id]/page.tsx
@@ -1,14 +1,29 @@
-import { FinanceForm } from "@/components/finance-form"
-import { getEntryById } from "@/lib/server-data" // Import from server-data instead
-import { notFound } from "next/navigation"
+import { FinanceForm } from "@/components/finance-form";
+import { getEntryById } from "@/lib/server-data";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { redirect, notFound } from "next/navigation";
 
-export default async function EditEntryPage({ params }: { params: { id: string } }) {
-  // Ensure params is fully resolved before accessing properties
-  const {id} = await params
-  const entry = await getEntryById(id)
+export default async function EditEntryPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  // SECURITY: this page used to load any entry by id without checking
+  // ownership, so an authenticated user could browse to /edit/<other-id>
+  // and view/edit another user's row. We now require a session and pass
+  // it down to the server data layer, which scopes the lookup to the
+  // current user's rows.
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect("/auth/signin");
+  }
+
+  const { id } = await params;
+  const entry = await getEntryById(id, session);
 
   if (!entry) {
-    notFound()
+    notFound();
   }
 
   return (
@@ -16,6 +31,5 @@ export default async function EditEntryPage({ params }: { params: { id: string }
       <h1 className="text-3xl font-bold mb-6">Editar Entrada</h1>
       <FinanceForm entry={entry} />
     </main>
-  )
+  );
 }
-

--- a/components/analytics-filter.tsx
+++ b/components/analytics-filter.tsx
@@ -28,9 +28,10 @@ export interface AnalyticsFilterProps {
   platforms: (string | null | undefined)[];
   types: (string | null | undefined)[];
   years: number[];
+  tipoToQueMap?: Map<string, Set<string>>;
 }
 
-export function AnalyticsFilter({ value, onChange, actions, categories, platforms, types, years }: AnalyticsFilterProps) {
+export function AnalyticsFilter({ value, onChange, actions, categories, platforms, types, years, tipoToQueMap }: AnalyticsFilterProps) {
   const [open, setOpen] = useState(false);
   const now = new Date();
 
@@ -47,6 +48,21 @@ export function AnalyticsFilter({ value, onChange, actions, categories, platform
     onChange({ ...value, from: startOfYear(new Date(year, 0, 1)), to: endOfYear(new Date(year, 0, 1)) });
   };
 
+  // Determine available que options based on selected tipo
+  const selectedTipo = Array.isArray(value.types) ? value.types[0] : value.types;
+  const availableQue = selectedTipo && tipoToQueMap?.has(selectedTipo)
+    ? Array.from(tipoToQueMap.get(selectedTipo)!).sort()
+    : categories;
+
+  const handleTipoChange = (tipo: string) => {
+    // Reset que when tipo changes
+    onChange({ ...value, types: tipo, categories: undefined });
+  };
+
+  const handleQueChange = (que: string) => {
+    onChange({ ...value, categories: que });
+  };
+
   return (
     <div className="flex flex-wrap gap-2 items-end mb-4">
       <Input
@@ -60,7 +76,7 @@ export function AnalyticsFilter({ value, onChange, actions, categories, platform
         onValueChange={action => onChange({ ...value, actions: action })}
       >
         <SelectTrigger className="w-36">
-          <SelectValue placeholder="Acciones" />
+          <SelectValue placeholder="Acción" />
         </SelectTrigger>
         <SelectContent>
           {actions.map(a => (
@@ -68,15 +84,30 @@ export function AnalyticsFilter({ value, onChange, actions, categories, platform
           ))}
         </SelectContent>
       </Select>
+      {/* Tipo (general) comes first */}
       <Select
-        value={Array.isArray(value.categories) ? value.categories[0] || "" : value.categories || ""}
-        onValueChange={category => onChange({ ...value, categories: category })}
+        value={selectedTipo || ""}
+        onValueChange={handleTipoChange}
       >
-        <SelectTrigger className="w-36">
-          <SelectValue placeholder="Categorías" />
+        <SelectTrigger className="w-40">
+          <SelectValue placeholder="Tipo (general)" />
         </SelectTrigger>
         <SelectContent>
-          {categories.map(c => (
+          {types.filter((t): t is string => t !== null && t !== undefined).map(t => (
+            <SelectItem key={t} value={t}>{t}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {/* Que (specific) cascades from tipo */}
+      <Select
+        value={Array.isArray(value.categories) ? value.categories[0] || "" : value.categories || ""}
+        onValueChange={handleQueChange}
+      >
+        <SelectTrigger className="w-40">
+          <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
+        </SelectTrigger>
+        <SelectContent>
+          {availableQue.map(c => (
             <SelectItem key={c} value={c}>{c}</SelectItem>
           ))}
         </SelectContent>
@@ -86,24 +117,11 @@ export function AnalyticsFilter({ value, onChange, actions, categories, platform
         onValueChange={platform => onChange({ ...value, platforms: platform })}
       >
         <SelectTrigger className="w-36">
-          <SelectValue placeholder="Plataformas" />
+          <SelectValue placeholder="Plataforma" />
         </SelectTrigger>
         <SelectContent>
           {platforms.filter((p): p is string => p !== null && p !== undefined).map(p => (
             <SelectItem key={p} value={p}>{p}</SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <Select
-        value={Array.isArray(value.types) ? value.types[0] || "" : value.types || ""}
-        onValueChange={type => onChange({ ...value, types: type })}
-      >
-        <SelectTrigger className="w-36">
-          <SelectValue placeholder="Tipos" />
-        </SelectTrigger>
-        <SelectContent>
-          {types.filter((t): t is string => t !== null && t !== undefined).map(t => (
-            <SelectItem key={t} value={t}>{t}</SelectItem>
           ))}
         </SelectContent>
       </Select>

--- a/components/analytics/CategoryDeepDive.tsx
+++ b/components/analytics/CategoryDeepDive.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { CategoryPlatformDatum } from "@/lib/analytics-charts";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface CategoryDeepDiveProps {
+  categoryData: Array<{ category: string; total: number; count?: number; action?: string | null }>;
+  categoryPlatformData: CategoryPlatformDatum[];
+  getChartData: (data: CategoryPlatformDatum[], category: string) => ChartData<'bar', number[], string> & { details?: Array<{ platform: string; total: number; count: number }> };
+  getChartOptions: () => ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function CategoryDeepDive({
+  categoryData,
+  categoryPlatformData,
+  getChartData,
+  getChartOptions,
+  loading,
+}: CategoryDeepDiveProps) {
+  // Get expense categories only, sorted by total spend
+  const expenseCategories = categoryData
+    .filter((item) => item.action === "Gasto" || !item.action)
+    .sort((a, b) => Math.abs(Number(b.total)) - Math.abs(Number(a.total)))
+    .map((item) => item.category);
+
+  const uniqueCategories = Array.from(new Set(expenseCategories));
+  const [selectedCategory, setSelectedCategory] = useState<string>(
+    uniqueCategories[0] || "Comida"
+  );
+
+  const chartData = getChartData(categoryPlatformData, selectedCategory);
+  const chartOptions = getChartOptions();
+
+  const categoryTotal = categoryData
+    .filter((item) => item.category === selectedCategory)
+    .reduce((sum, item) => sum + Math.abs(Number(item.total)), 0);
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Análisis por Categoría</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Total en <span className="font-semibold">{selectedCategory}</span>:{" "}
+            {categoryTotal.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+          </p>
+        </div>
+        <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Selecciona categoría" />
+          </SelectTrigger>
+          <SelectContent>
+            {uniqueCategories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="h-72">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : (chartData?.labels?.length ?? 0) > 0 ? (
+              <Bar data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No hay datos de plataforma para esta categoría
+              </div>
+            )}
+          </div>
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">
+              Desglose por plataforma
+            </h4>
+            {loading ? (
+              <div className="flex items-center justify-center h-48">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : chartData.details && chartData.details.length > 0 ? (
+              <div className="space-y-2 max-h-72 overflow-y-auto">
+                {chartData.details.map((item) => {
+                  const pct = categoryTotal > 0 ? (item.total / categoryTotal) * 100 : 0;
+                  return (
+                    <div key={item.platform} className="flex items-center justify-between text-sm">
+                      <div className="flex-1 min-w-0 mr-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="font-medium truncate">{item.platform}</span>
+                          <span className="text-muted-foreground ml-2 shrink-0">
+                            {item.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                          </span>
+                        </div>
+                        <div className="w-full bg-muted rounded-full h-2">
+                          <div
+                            className="bg-primary h-2 rounded-full transition-all"
+                            style={{ width: `${Math.min(pct, 100)}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between mt-0.5">
+                          <span className="text-xs text-muted-foreground">{pct.toFixed(1)}%</span>
+                          <span className="text-xs text-muted-foreground">{item.count} mov.</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+                No hay datos de plataforma para esta categoría
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/CategoryIntelligence.tsx
+++ b/components/analytics/CategoryIntelligence.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { CategoryStatDatum, CategoryPlatformDatum, CategoryDatum } from "@/lib/analytics-charts";
+import { CreditCard, Wallet, TrendingUp, Hash, Calendar, Store } from "lucide-react";
+
+interface CategoryIntelligenceProps {
+  categoryStats: CategoryStatDatum[];
+  categoryPlatformData: CategoryPlatformDatum[];
+  categoryData: CategoryDatum[];
+  temporalData: Array<{ period: string }>;
+  loading: boolean;
+}
+
+export function CategoryIntelligence({
+  categoryStats,
+  categoryPlatformData,
+  categoryData,
+  temporalData,
+  loading,
+}: CategoryIntelligenceProps) {
+  // Get categories that have stats
+  const categories = Array.from(new Set(categoryStats.map((d) => d.category))).sort();
+  const [selectedCategory, setSelectedCategory] = useState<string>(
+    categories[0] || "",
+  );
+
+  const stats = categoryStats.filter((s) => s.category === selectedCategory);
+  const expenseStats = stats.find((s) => s.action === "Gasto");
+
+  // Top platform for this category
+  const platformBreakdown = categoryPlatformData
+    .filter((p) => p.category === selectedCategory)
+    .sort((a, b) => Math.abs(Number(b.total)) - Math.abs(Number(a.total)));
+  const topPlatform = platformBreakdown[0];
+
+  // Total for this category
+  const totalForCategory = categoryData
+    .filter((c) => c.category === selectedCategory)
+    .reduce((sum, c) => sum + Math.abs(Number(c.total)), 0);
+
+  // Total of all expenses
+  const totalExpenses = categoryData
+    .filter((c) => c.action === "Gasto" || !c.action)
+    .reduce((sum, c) => sum + Math.abs(Number(c.total)), 0);
+
+  const pctOfTotal = totalExpenses > 0 ? (totalForCategory / totalExpenses) * 100 : 0;
+
+  // Count distinct periods for frequency calculation
+  const distinctPeriods = new Set(temporalData.map((t) => t.period)).size;
+  const transactionsPerPeriod =
+    expenseStats && distinctPeriods > 0
+      ? expenseStats.count / distinctPeriods
+      : 0;
+
+  const statCards = [
+    {
+      label: "Transacción media",
+      value: expenseStats
+        ? expenseStats.avg.toLocaleString("es-ES", {
+            style: "currency",
+            currency: "EUR",
+          })
+        : "—",
+      icon: CreditCard,
+      color: "text-blue-600",
+      bg: "bg-blue-50",
+    },
+    {
+      label: "Mayor gasto",
+      value: expenseStats
+        ? expenseStats.max.toLocaleString("es-ES", {
+            style: "currency",
+            currency: "EUR",
+          })
+        : "—",
+      icon: TrendingUp,
+      color: "text-red-600",
+      bg: "bg-red-50",
+    },
+    {
+      label: "Menor gasto",
+      value: expenseStats
+        ? expenseStats.min.toLocaleString("es-ES", {
+            style: "currency",
+            currency: "EUR",
+          })
+        : "—",
+      icon: Wallet,
+      color: "text-green-600",
+      bg: "bg-green-50",
+    },
+    {
+      label: "Total transacciones",
+      value: expenseStats ? `${expenseStats.count}` : "—",
+      icon: Hash,
+      color: "text-purple-600",
+      bg: "bg-purple-50",
+    },
+    {
+      label: "Frecuencia",
+      value: expenseStats
+        ? `${transactionsPerPeriod.toFixed(1)} / ${distinctPeriods > 12 ? "año" : "mes"}`
+        : "—",
+      icon: Calendar,
+      color: "text-amber-600",
+      bg: "bg-amber-50",
+    },
+    {
+      label: "Plataforma principal",
+      value: topPlatform?.platform || "—",
+      icon: Store,
+      color: "text-indigo-600",
+      bg: "bg-indigo-50",
+    },
+  ];
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Inteligencia de Categoría</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Métricas detalladas para una categoría concreta
+          </p>
+        </div>
+        <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+          <SelectTrigger className="w-[220px]">
+            <SelectValue placeholder="Selecciona categoría" />
+          </SelectTrigger>
+          <SelectContent className="max-h-[300px]">
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : (
+          <>
+            <div className="mb-4 p-3 rounded-lg bg-muted/50 flex items-center justify-between">
+              <div>
+                <div className="text-sm text-muted-foreground">Total en {selectedCategory}</div>
+                <div className="text-2xl font-bold">
+                  {totalForCategory.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-sm text-muted-foreground">Del gasto total</div>
+                <div className="text-2xl font-bold">{pctOfTotal.toFixed(1)}%</div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {statCards.map((stat) => {
+                const Icon = stat.icon;
+                return (
+                  <div
+                    key={stat.label}
+                    className={`p-3 rounded-lg ${stat.bg} border border-opacity-20`}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <Icon className={`h-4 w-4 ${stat.color}`} />
+                      <span className="text-xs text-muted-foreground">{stat.label}</span>
+                    </div>
+                    <div className={`text-lg font-bold ${stat.color}`}>{stat.value}</div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Platform breakdown mini */}
+            {platformBreakdown.length > 0 && (
+              <div className="mt-4">
+                <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                  Distribución por plataforma
+                </h4>
+                <div className="space-y-2">
+                  {platformBreakdown.slice(0, 5).map((p) => {
+                    const amount = Math.abs(Number(p.total));
+                    const pct =
+                      totalForCategory > 0 ? (amount / totalForCategory) * 100 : 0;
+                    return (
+                      <div key={p.platform} className="flex items-center gap-3 text-sm">
+                        <span className="w-24 truncate text-muted-foreground">
+                          {p.platform}
+                        </span>
+                        <div className="flex-1 bg-muted rounded-full h-2">
+                          <div
+                            className="bg-primary h-2 rounded-full transition-all"
+                            style={{ width: `${Math.min(pct, 100)}%` }}
+                          />
+                        </div>
+                        <span className="w-16 text-right font-medium">
+                          {pct.toFixed(0)}%
+                        </span>
+                        <span className="w-20 text-right text-muted-foreground">
+                          {amount.toLocaleString("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                          })}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/CategoryTrendTracker.tsx
+++ b/components/analytics/CategoryTrendTracker.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Line } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { CategoryTemporalDatum } from "@/lib/analytics-charts";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface CategoryTrendTrackerProps {
+  categoryTemporalData: CategoryTemporalDatum[];
+  getChartData: (
+    data: CategoryTemporalDatum[],
+    category: string,
+    groupBy: "month" | "year",
+  ) => ChartData<'line', number[], string> & { counts?: number[]; trendSlope?: number };
+  getChartOptions: () => ChartOptions<'line'>;
+  groupBy: "month" | "year";
+  loading: boolean;
+}
+
+export function CategoryTrendTracker({
+  categoryTemporalData,
+  getChartData,
+  getChartOptions,
+  groupBy,
+  loading,
+}: CategoryTrendTrackerProps) {
+  // Get unique categories that have temporal data
+  const categories = Array.from(
+    new Set(categoryTemporalData.map((d) => d.category)),
+  ).sort();
+
+  const [selectedCategory, setSelectedCategory] = useState<string>(
+    categories.find((c) =>
+      ["Fiesta", "Gym", "Comida", "Viajes/ Transporte"].includes(c),
+    ) || categories[0] || "",
+  );
+
+  const chartData = getChartData(categoryTemporalData, selectedCategory, groupBy);
+  const chartOptions = getChartOptions();
+
+  // Determine trend direction
+  const trendSlope = chartData.trendSlope || 0;
+  const trendDirection =
+    trendSlope > 0.5 ? "up" : trendSlope < -0.5 ? "down" : "flat";
+
+  // Compute total spend and avg per period for this category
+  const categoryData = categoryTemporalData.filter(
+    (d) => d.category === selectedCategory && d.action === "Gasto",
+  );
+  const totalSpend = categoryData.reduce(
+    (sum, d) => sum + Math.abs(Number(d.total)),
+    0,
+  );
+  const avgPerPeriod =
+    categoryData.length > 0 ? totalSpend / categoryData.length : 0;
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Tendencia por Categoría</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Evolución de <span className="font-semibold">{selectedCategory}</span> a lo largo del tiempo
+          </p>
+        </div>
+        <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+          <SelectTrigger className="w-[220px]">
+            <SelectValue placeholder="Selecciona categoría" />
+          </SelectTrigger>
+          <SelectContent className="max-h-[300px]">
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          <div className="lg:col-span-3 h-80">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : (chartData?.labels?.length ?? 0) > 0 ? (
+              <Line data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No hay datos temporales para esta categoría
+              </div>
+            )}
+          </div>
+          <div className="space-y-4">
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Tendencia</div>
+              <div className="flex items-center gap-2">
+                {trendDirection === "up" ? (
+                  <>
+                    <TrendingUp className="h-5 w-5 text-red-500" />
+                    <span className="text-lg font-bold text-red-500">Subiendo</span>
+                  </>
+                ) : trendDirection === "down" ? (
+                  <>
+                    <TrendingDown className="h-5 w-5 text-green-500" />
+                    <span className="text-lg font-bold text-green-500">Bajando</span>
+                  </>
+                ) : (
+                  <>
+                    <Minus className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-lg font-bold text-muted-foreground">Estable</span>
+                  </>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {trendSlope > 0 ? "+" : ""}
+                {trendSlope.toFixed(0)} €/{groupBy === "year" ? "año" : "mes"} de media
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Total gastado</div>
+              <div className="text-xl font-bold">
+                {totalSpend.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">
+                Media por {groupBy === "year" ? "año" : "mes"}
+              </div>
+              <div className="text-xl font-bold">
+                {avgPerPeriod.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Periodos con datos</div>
+              <div className="text-xl font-bold">{categoryData.length}</div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/IntelligenceExplorer.tsx
+++ b/components/analytics/IntelligenceExplorer.tsx
@@ -1,0 +1,268 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { CategoryStatDatum, CategoryPlatformDatum, CategoryDatum } from "@/lib/analytics-charts";
+import { CreditCard, Wallet, TrendingUp, Hash, Calendar, Store } from "lucide-react";
+
+interface IntelligenceExplorerProps {
+  categoryStats: CategoryStatDatum[];
+  categoryPlatformData: CategoryPlatformDatum[];
+  categoryData: CategoryDatum[];
+  temporalData: Array<{ period: string }>;
+  types: string[];
+  loading: boolean;
+}
+
+export function IntelligenceExplorer({
+  categoryStats,
+  categoryPlatformData,
+  categoryData,
+  temporalData,
+  types,
+  loading,
+}: IntelligenceExplorerProps) {
+  const [selectedTipo, setSelectedTipo] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("");
+
+  // Build tipo → que mapping
+  const tipoToQueMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const item of categoryStats) {
+      if (!map.has(item.type)) map.set(item.type, new Set());
+      map.get(item.type)!.add(item.category);
+    }
+    return map;
+  }, [categoryStats]);
+
+  const availableQue = selectedTipo && tipoToQueMap.has(selectedTipo)
+    ? Array.from(tipoToQueMap.get(selectedTipo)!).sort()
+    : [];
+
+  const handleTipoChange = (tipo: string) => {
+    setSelectedTipo(tipo);
+    setSelectedQue("");
+  };
+
+  // Determine what stats to show
+  const isTipoOnly = selectedTipo && !selectedQue;
+  const isQue = !!selectedQue;
+
+  // Stats computation
+  let stats: CategoryStatDatum[] = [];
+  let totalForSelection = 0;
+
+  if (isTipoOnly) {
+    stats = categoryStats.filter((s) => s.type === selectedTipo);
+    totalForSelection = categoryData
+      .filter((c) => c.type === selectedTipo)
+      .reduce((sum, c) => sum + Math.abs(Number(c.total)), 0);
+  } else if (isQue) {
+    stats = categoryStats.filter((s) => s.category === selectedQue);
+    totalForSelection = categoryData
+      .filter((c) => c.category === selectedQue)
+      .reduce((sum, c) => sum + Math.abs(Number(c.total)), 0);
+  }
+
+  const expenseStats = stats.find((s) => s.action === "Gasto");
+
+  // Total expenses for percentage
+  const totalExpenses = categoryData
+    .filter((c) => c.action === "Gasto" || !c.action)
+    .reduce((sum, c) => sum + Math.abs(Number(c.total)), 0);
+
+  const pctOfTotal = totalExpenses > 0 ? (totalForSelection / totalExpenses) * 100 : 0;
+
+  const distinctPeriods = new Set(temporalData.map((t) => t.period)).size;
+  const transactionsPerPeriod =
+    expenseStats && distinctPeriods > 0
+      ? expenseStats.count / distinctPeriods
+      : 0;
+
+  // Platform breakdown
+  let platformBreakdown: CategoryPlatformDatum[] = [];
+  if (isTipoOnly) {
+    // Aggregate platforms for all que within tipo
+    const raw = categoryPlatformData.filter((p) => {
+      // We need to know the tipo for each platform entry... but categoryPlatformData doesn't have tipo
+      // So we use categoryData to map que → tipo
+      const tipoForQue = categoryData.find((c) => c.category === p.category)?.type;
+      return tipoForQue === selectedTipo;
+    });
+    const aggregated = new Map<string, number>();
+    for (const item of raw) {
+      const current = aggregated.get(item.platform) || 0;
+      aggregated.set(item.platform, current + Math.abs(Number(item.total)));
+    }
+    platformBreakdown = Array.from(aggregated.entries())
+      .map(([platform, total]) => ({ platform, category: "", total, count: 0 }))
+      .sort((a, b) => b.total - a.total);
+  } else if (isQue) {
+    platformBreakdown = categoryPlatformData
+      .filter((p) => p.category === selectedQue)
+      .sort((a, b) => Math.abs(Number(b.total)) - Math.abs(Number(a.total)));
+  }
+
+  const topPlatform = platformBreakdown[0];
+
+  const statCards = [
+    {
+      label: "Transacción media",
+      value: expenseStats
+        ? expenseStats.avg.toLocaleString("es-ES", { style: "currency", currency: "EUR" })
+        : "—",
+      icon: CreditCard,
+      color: "text-blue-600",
+      bg: "bg-blue-50",
+    },
+    {
+      label: "Mayor gasto",
+      value: expenseStats
+        ? expenseStats.max.toLocaleString("es-ES", { style: "currency", currency: "EUR" })
+        : "—",
+      icon: TrendingUp,
+      color: "text-red-600",
+      bg: "bg-red-50",
+    },
+    {
+      label: "Menor gasto",
+      value: expenseStats
+        ? expenseStats.min.toLocaleString("es-ES", { style: "currency", currency: "EUR" })
+        : "—",
+      icon: Wallet,
+      color: "text-green-600",
+      bg: "bg-green-50",
+    },
+    {
+      label: "Total transacciones",
+      value: expenseStats ? `${expenseStats.count}` : "—",
+      icon: Hash,
+      color: "text-purple-600",
+      bg: "bg-purple-50",
+    },
+    {
+      label: "Frecuencia",
+      value: expenseStats
+        ? `${transactionsPerPeriod.toFixed(1)} / ${distinctPeriods > 12 ? "año" : "mes"}`
+        : "—",
+      icon: Calendar,
+      color: "text-amber-600",
+      bg: "bg-amber-50",
+    },
+    {
+      label: "Plataforma principal",
+      value: topPlatform?.platform || "—",
+      icon: Store,
+      color: "text-indigo-600",
+      bg: "bg-indigo-50",
+    },
+  ];
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Inteligencia Financiera</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Métricas detalladas por tipo o categoría
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Select value={selectedTipo} onValueChange={handleTipoChange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Tipo (general)" />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              {types.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={selectedQue} onValueChange={setSelectedQue} disabled={!selectedTipo}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              {availableQue.map((q) => (
+                <SelectItem key={q} value={q}>
+                  {q}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : selectedTipo ? (
+          <>
+            <div className="mb-4 p-3 rounded-lg bg-muted/50 flex items-center justify-between">
+              <div>
+                <div className="text-sm text-muted-foreground">
+                  Total en {selectedQue || selectedTipo}
+                </div>
+                <div className="text-2xl font-bold">
+                  {totalForSelection.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-sm text-muted-foreground">Del gasto total</div>
+                <div className="text-2xl font-bold">{pctOfTotal.toFixed(1)}%</div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              {statCards.map((stat) => {
+                const Icon = stat.icon;
+                return (
+                  <div key={stat.label} className={`p-3 rounded-lg ${stat.bg} border border-opacity-20`}>
+                    <div className="flex items-center gap-2 mb-1">
+                      <Icon className={`h-4 w-4 ${stat.color}`} />
+                      <span className="text-xs text-muted-foreground">{stat.label}</span>
+                    </div>
+                    <div className={`text-lg font-bold ${stat.color}`}>{stat.value}</div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {platformBreakdown.length > 0 && (
+              <div className="mt-4">
+                <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                  Distribución por plataforma
+                </h4>
+                <div className="space-y-2">
+                  {platformBreakdown.slice(0, 5).map((p) => {
+                    const amount = Math.abs(Number(p.total));
+                    const pct = totalForSelection > 0 ? (amount / totalForSelection) * 100 : 0;
+                    return (
+                      <div key={p.platform} className="flex items-center gap-3 text-sm">
+                        <span className="w-24 truncate text-muted-foreground">{p.platform}</span>
+                        <div className="flex-1 bg-muted rounded-full h-2">
+                          <div className="bg-primary h-2 rounded-full transition-all" style={{ width: `${Math.min(pct, 100)}%` }} />
+                        </div>
+                        <span className="w-16 text-right font-medium">{pct.toFixed(0)}%</span>
+                        <span className="w-20 text-right text-muted-foreground">
+                          {amount.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-48 text-muted-foreground">
+            Selecciona un tipo para ver su inteligencia financiera
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/IntelligenceExplorer.tsx
+++ b/components/analytics/IntelligenceExplorer.tsx
@@ -22,7 +22,7 @@ export function IntelligenceExplorer({
   loading,
 }: IntelligenceExplorerProps) {
   const [selectedTipo, setSelectedTipo] = useState<string>("");
-  const [selectedQue, setSelectedQue] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("__all__");
 
   // Build tipo → que mapping
   const tipoToQueMap = useMemo(() => {
@@ -40,12 +40,12 @@ export function IntelligenceExplorer({
 
   const handleTipoChange = (tipo: string) => {
     setSelectedTipo(tipo);
-    setSelectedQue("");
+    setSelectedQue("__all__");
   };
 
   // Determine what stats to show
-  const isTipoOnly = selectedTipo && !selectedQue;
-  const isQue = !!selectedQue;
+  const isTipoOnly = selectedTipo && selectedQue === "__all__";
+  const isQue = selectedTipo && selectedQue !== "__all__";
 
   // Stats computation
   let stats: CategoryStatDatum[] = [];
@@ -184,7 +184,7 @@ export function IntelligenceExplorer({
               <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
             </SelectTrigger>
             <SelectContent className="max-h-[300px]">
-              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              <SelectItem value="__all__">Todas (ver tipo agregado)</SelectItem>
               {availableQue.map((q) => (
                 <SelectItem key={q} value={q}>
                   {q}

--- a/components/analytics/PlatformChart.tsx
+++ b/components/analytics/PlatformChart.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+// Register Chart.js components
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface PlatformChartProps {
+  data: ChartData<'bar', number[], string>;
+  options: ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function PlatformChart({ data, options, loading }: PlatformChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Gasto por Plataforma</CardTitle>
+      </CardHeader>
+      <CardContent className="h-80">
+        {loading ? (
+          <div className="flex items-center justify-center h-full">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : (data?.labels?.length ?? 0) > 0 ? (
+          <Bar data={data} options={options} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            No hay datos disponibles
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/SavingsRateCard.tsx
+++ b/components/analytics/SavingsRateCard.tsx
@@ -1,0 +1,62 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PiggyBank } from "lucide-react";
+
+interface SavingsRateCardProps {
+  income: number;
+  expenses: number;
+}
+
+export function SavingsRateCard({ income, expenses }: SavingsRateCardProps) {
+  const savings = income - expenses;
+  const rate = income > 0 ? (savings / income) * 100 : 0;
+  const isPositive = savings >= 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+          <PiggyBank className="h-4 w-4" />
+          Tasa de Ahorro
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-2xl font-bold ${isPositive ? "text-green-600" : "text-destructive"}`}>
+          {rate.toFixed(1)}%
+        </div>
+        <div className="text-sm text-muted-foreground mt-1">
+          {isPositive ? "Ahorrando" : "Gastando más de lo que entra"}
+        </div>
+        <div className="mt-3">
+          <div className="flex justify-between text-xs text-muted-foreground mb-1">
+            <span>Gastos</span>
+            <span>{Math.min(100, Math.max(0, 100 - rate)).toFixed(0)}%</span>
+          </div>
+          <div className="w-full bg-muted rounded-full h-2.5">
+            <div
+              className={`h-2.5 rounded-full transition-all ${isPositive ? "bg-green-500" : "bg-destructive"}`}
+              style={{ width: `${Math.min(100, Math.max(0, rate))}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-xs mt-2">
+            <span className="text-muted-foreground">Ingresos</span>
+            <span className="font-medium">
+              {income.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+            </span>
+          </div>
+          <div className="flex justify-between text-xs mt-1">
+            <span className="text-muted-foreground">Gastos</span>
+            <span className="font-medium">
+              {expenses.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+            </span>
+          </div>
+          <div className="flex justify-between text-xs mt-1">
+            <span className="text-muted-foreground">Neto</span>
+            <span className={`font-medium ${isPositive ? "text-green-600" : "text-destructive"}`}>
+              {savings.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/SeasonalExplorer.tsx
+++ b/components/analytics/SeasonalExplorer.tsx
@@ -40,7 +40,7 @@ export function SeasonalExplorer({
   loading,
 }: SeasonalExplorerProps) {
   const [selectedTipo, setSelectedTipo] = useState<string>("");
-  const [selectedQue, setSelectedQue] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("__all__");
 
   // Build tipo → que mapping
   const tipoToQueMap = useMemo(() => {
@@ -58,7 +58,7 @@ export function SeasonalExplorer({
 
   const handleTipoChange = (tipo: string) => {
     setSelectedTipo(tipo);
-    setSelectedQue("");
+    setSelectedQue("__all__");
   };
 
   // Compute seasonal data
@@ -144,7 +144,7 @@ export function SeasonalExplorer({
               <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
             </SelectTrigger>
             <SelectContent className="max-h-[300px]">
-              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              <SelectItem value="__all__">Todas (ver tipo agregado)</SelectItem>
               {availableQue.map((q) => (
                 <SelectItem key={q} value={q}>
                   {q}

--- a/components/analytics/SeasonalExplorer.tsx
+++ b/components/analytics/SeasonalExplorer.tsx
@@ -1,0 +1,219 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { CategoryTemporalDatum } from "@/lib/analytics-charts";
+import { Sun, Snowflake, Leaf, Flower2 } from "lucide-react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface SeasonalExplorerProps {
+  categoryTemporalData: CategoryTemporalDatum[];
+  types: string[];
+  getChartData: (data: Array<{ monthName: string; total: number }>) => ChartData<'bar', number[], string>;
+  getChartOptions: () => ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function SeasonalExplorer({
+  categoryTemporalData,
+  types,
+  getChartData,
+  getChartOptions,
+  loading,
+}: SeasonalExplorerProps) {
+  const [selectedTipo, setSelectedTipo] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("");
+
+  // Build tipo → que mapping
+  const tipoToQueMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const item of categoryTemporalData) {
+      if (!map.has(item.type)) map.set(item.type, new Set());
+      map.get(item.type)!.add(item.category);
+    }
+    return map;
+  }, [categoryTemporalData]);
+
+  const availableQue = selectedTipo && tipoToQueMap.has(selectedTipo)
+    ? Array.from(tipoToQueMap.get(selectedTipo)!).sort()
+    : [];
+
+  const handleTipoChange = (tipo: string) => {
+    setSelectedTipo(tipo);
+    setSelectedQue("");
+  };
+
+  // Compute seasonal data
+  const seasonalData = useMemo(() => {
+    const monthNames = [
+      "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+      "Jul", "Ago", "Sep", "Oct", "Nov", "Dic",
+    ];
+
+    const filtered = categoryTemporalData.filter((item) => {
+      if (selectedQue) return item.category === selectedQue && item.action === "Gasto";
+      if (selectedTipo) return item.type === selectedTipo && item.action === "Gasto";
+      return false;
+    });
+
+    const byMonth = new Map<number, { total: number; count: number; yearCount: number }>();
+    for (let i = 0; i < 12; i++) {
+      byMonth.set(i, { total: 0, count: 0, yearCount: 0 });
+    }
+
+    for (const item of filtered) {
+      const d = new Date(item.period);
+      const month = d.getUTCMonth();
+      const existing = byMonth.get(month)!;
+      existing.total += Math.abs(Number(item.total));
+      existing.count += item.count || 0;
+      existing.yearCount += 1;
+    }
+
+    return Array.from(byMonth.entries()).map(([month, data]) => ({
+      month,
+      monthName: monthNames[month],
+      total: data.yearCount > 0 ? data.total / data.yearCount : 0,
+      count: data.yearCount > 0 ? Math.round(data.count / data.yearCount) : 0,
+    }));
+  }, [categoryTemporalData, selectedTipo, selectedQue]);
+
+  const chartData = getChartData(seasonalData);
+  const chartOptions = getChartOptions();
+
+  const sorted = [...seasonalData].sort((a, b) => b.total - a.total);
+  const peakMonth = sorted[0];
+  const lowMonth = sorted[sorted.length - 1];
+
+  const seasons = [
+    { name: "Invierno", months: [11, 0, 1], icon: Snowflake, color: "text-blue-500", bg: "bg-blue-50" },
+    { name: "Primavera", months: [2, 3, 4], icon: Flower2, color: "text-green-500", bg: "bg-green-50" },
+    { name: "Verano", months: [5, 6, 7], icon: Sun, color: "text-amber-500", bg: "bg-amber-50" },
+    { name: "Otoño", months: [8, 9, 10], icon: Leaf, color: "text-orange-500", bg: "bg-orange-50" },
+  ];
+
+  const seasonTotals = seasons.map((season) => {
+    const total = seasonalData
+      .filter((s) => season.months.includes(s.month))
+      .reduce((sum, s) => sum + s.total, 0);
+    return { ...season, total };
+  });
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Patrones Estacionales</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            ¿En qué meses gastas más?
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Select value={selectedTipo} onValueChange={handleTipoChange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Tipo (general)" />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              {types.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={selectedQue} onValueChange={setSelectedQue} disabled={!selectedTipo}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              {availableQue.map((q) => (
+                <SelectItem key={q} value={q}>
+                  {q}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : selectedTipo ? (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2 h-64">
+              {(chartData?.labels?.length ?? 0) > 0 ? (
+                <Bar data={chartData} options={chartOptions} />
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  No hay datos estacionales
+                </div>
+              )}
+            </div>
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="p-3 rounded-lg bg-red-50 border border-red-100">
+                  <div className="text-xs text-red-600 font-medium mb-1">Pico</div>
+                  <div className="text-lg font-bold text-red-700">{peakMonth?.monthName}</div>
+                  <div className="text-xs text-red-600">
+                    {peakMonth?.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                  </div>
+                </div>
+                <div className="p-3 rounded-lg bg-green-50 border border-green-100">
+                  <div className="text-xs text-green-600 font-medium mb-1">Valle</div>
+                  <div className="text-lg font-bold text-green-700">{lowMonth?.monthName}</div>
+                  <div className="text-xs text-green-600">
+                    {lowMonth?.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Por estación
+                </h4>
+                {seasonTotals.map((season) => {
+                  const Icon = season.icon;
+                  return (
+                    <div key={season.name} className={`flex items-center justify-between p-2 rounded-lg ${season.bg}`}>
+                      <div className="flex items-center gap-2">
+                        <Icon className={`h-4 w-4 ${season.color}`} />
+                        <span className="text-sm font-medium">{season.name}</span>
+                      </div>
+                      <span className={`text-sm font-bold ${season.color}`}>
+                        {season.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-64 text-muted-foreground">
+            Selecciona un tipo para ver sus patrones estacionales
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/SeasonalPatterns.tsx
+++ b/components/analytics/SeasonalPatterns.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { SeasonalItem } from "@/lib/analytics-charts";
+import { Sun, Snowflake, Leaf, Flower2 } from "lucide-react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface SeasonalPatternsProps {
+  categories: string[];
+  getSeasonalData: (category: string) => SeasonalItem[];
+  getChartData: (data: SeasonalItem[]) => ChartData<'bar', number[], string>;
+  getChartOptions: () => ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function SeasonalPatterns({
+  categories,
+  getSeasonalData,
+  getChartData,
+  getChartOptions,
+  loading,
+}: SeasonalPatternsProps) {
+  const [selectedCategory, setSelectedCategory] = useState<string>(
+    categories[0] || "",
+  );
+
+  const seasonalData = getSeasonalData(selectedCategory);
+  const chartData = getChartData(seasonalData);
+  const chartOptions = getChartOptions();
+
+  // Find peak and low months
+  const sorted = [...seasonalData].sort((a, b) => b.total - a.total);
+  const peakMonth = sorted[0];
+  const lowMonth = sorted[sorted.length - 1];
+
+  // Season totals
+  const seasons = [
+    {
+      name: "Invierno",
+      months: [11, 0, 1],
+      icon: Snowflake,
+      color: "text-blue-500",
+      bg: "bg-blue-50",
+    },
+    {
+      name: "Primavera",
+      months: [2, 3, 4],
+      icon: Flower2,
+      color: "text-green-500",
+      bg: "bg-green-50",
+    },
+    {
+      name: "Verano",
+      months: [5, 6, 7],
+      icon: Sun,
+      color: "text-amber-500",
+      bg: "bg-amber-50",
+    },
+    {
+      name: "Otoño",
+      months: [8, 9, 10],
+      icon: Leaf,
+      color: "text-orange-500",
+      bg: "bg-orange-50",
+    },
+  ];
+
+  const seasonTotals = seasons.map((season) => {
+    const total = seasonalData
+      .filter((s) => season.months.includes(s.month))
+      .reduce((sum, s) => sum + s.total, 0);
+    return { ...season, total };
+  });
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Patrones Estacionales</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            ¿En qué meses gastas más en <span className="font-semibold">{selectedCategory}</span>?
+          </p>
+        </div>
+        <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+          <SelectTrigger className="w-[220px]">
+            <SelectValue placeholder="Selecciona categoría" />
+          </SelectTrigger>
+          <SelectContent className="max-h-[300px]">
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 h-64">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : (chartData?.labels?.length ?? 0) > 0 ? (
+              <Bar data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No hay datos estacionales para esta categoría
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-4">
+            {/* Peak/Low */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="p-3 rounded-lg bg-red-50 border border-red-100">
+                <div className="text-xs text-red-600 font-medium mb-1">Pico</div>
+                <div className="text-lg font-bold text-red-700">{peakMonth?.monthName}</div>
+                <div className="text-xs text-red-600">
+                  {peakMonth?.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                </div>
+              </div>
+              <div className="p-3 rounded-lg bg-green-50 border border-green-100">
+                <div className="text-xs text-green-600 font-medium mb-1">Valle</div>
+                <div className="text-lg font-bold text-green-700">{lowMonth?.monthName}</div>
+                <div className="text-xs text-green-600">
+                  {lowMonth?.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                </div>
+              </div>
+            </div>
+
+            {/* Season totals */}
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Por estación
+              </h4>
+              {seasonTotals.map((season) => {
+                const Icon = season.icon;
+                return (
+                  <div
+                    key={season.name}
+                    className={`flex items-center justify-between p-2 rounded-lg ${season.bg}`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Icon className={`h-4 w-4 ${season.color}`} />
+                      <span className="text-sm font-medium">{season.name}</span>
+                    </div>
+                    <span className={`text-sm font-bold ${season.color}`}>
+                      {season.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/SpendingVelocity.tsx
+++ b/components/analytics/SpendingVelocity.tsx
@@ -1,0 +1,122 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { VelocityItem } from "@/lib/analytics-charts";
+import { TrendingUp, TrendingDown, AlertTriangle, ArrowUpRight, ArrowDownRight } from "lucide-react";
+
+interface SpendingVelocityProps {
+  velocities: VelocityItem[];
+  loading: boolean;
+}
+
+export function SpendingVelocity({ velocities, loading }: SpendingVelocityProps) {
+  const growing = velocities.filter((v) => v.direction === "up").slice(0, 3);
+  const shrinking = velocities.filter((v) => v.direction === "down").slice(0, 3);
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <AlertTriangle className="h-5 w-5 text-amber-500" />
+          Velocidad de Gasto
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Categorías que más han cambiado respecto al periodo anterior
+        </p>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Growing */}
+            <div>
+              <h4 className="text-sm font-semibold text-red-600 mb-3 flex items-center gap-1.5">
+                <TrendingUp className="h-4 w-4" />
+                Creciendo (alerta)
+              </h4>
+              <div className="space-y-3">
+                {growing.length > 0 ? (
+                  growing.map((item) => (
+                    <div
+                      key={item.category}
+                      className="flex items-center justify-between p-3 rounded-lg bg-red-50 border border-red-100"
+                    >
+                      <div className="flex-1 min-w-0 mr-3">
+                        <div className="font-medium text-sm truncate">
+                          {item.category}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {item.previous.toLocaleString("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                          })}{" "}
+                          →{" "}
+                          {item.current.toLocaleString("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                          })}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 text-red-600 font-bold text-sm shrink-0">
+                        <ArrowUpRight className="h-4 w-4" />
+                        +{item.changePercent.toFixed(0)}%
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-sm text-muted-foreground text-center py-4">
+                    Ninguna categoría creciendo significativamente
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Shrinking */}
+            <div>
+              <h4 className="text-sm font-semibold text-green-600 mb-3 flex items-center gap-1.5">
+                <TrendingDown className="h-4 w-4" />
+                Reduciendo (bien)
+              </h4>
+              <div className="space-y-3">
+                {shrinking.length > 0 ? (
+                  shrinking.map((item) => (
+                    <div
+                      key={item.category}
+                      className="flex items-center justify-between p-3 rounded-lg bg-green-50 border border-green-100"
+                    >
+                      <div className="flex-1 min-w-0 mr-3">
+                        <div className="font-medium text-sm truncate">
+                          {item.category}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5">
+                          {item.previous.toLocaleString("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                          })}{" "}
+                          →{" "}
+                          {item.current.toLocaleString("es-ES", {
+                            style: "currency",
+                            currency: "EUR",
+                          })}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 text-green-600 font-bold text-sm shrink-0">
+                        <ArrowDownRight className="h-4 w-4" />
+                        {item.changePercent.toFixed(0)}%
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div className="text-sm text-muted-foreground text-center py-4">
+                    Ninguna categoría reduciendo significativamente
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/SpendingVelocity.tsx
+++ b/components/analytics/SpendingVelocity.tsx
@@ -5,9 +5,10 @@ import { TrendingUp, TrendingDown, AlertTriangle, ArrowUpRight, ArrowDownRight }
 interface SpendingVelocityProps {
   velocities: VelocityItem[];
   loading: boolean;
+  title?: string;
 }
 
-export function SpendingVelocity({ velocities, loading }: SpendingVelocityProps) {
+export function SpendingVelocity({ velocities, loading, title = "Velocidad de Gasto" }: SpendingVelocityProps) {
   const growing = velocities.filter((v) => v.direction === "up").slice(0, 3);
   const shrinking = velocities.filter((v) => v.direction === "down").slice(0, 3);
 
@@ -16,7 +17,7 @@ export function SpendingVelocity({ velocities, loading }: SpendingVelocityProps)
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <AlertTriangle className="h-5 w-5 text-amber-500" />
-          Velocidad de Gasto
+          {title}
         </CardTitle>
         <p className="text-sm text-muted-foreground">
           Categorías que más han cambiado respecto al periodo anterior

--- a/components/analytics/TipoDeepDive.tsx
+++ b/components/analytics/TipoDeepDive.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { TipoQueDatum } from "@/lib/analytics-charts";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface TipoDeepDiveProps {
+  tipoQueData: TipoQueDatum[];
+  getChartData: (data: TipoQueDatum[], type: string) => ChartData<'bar', number[], string> & { details?: Array<{ category: string; total: number; count: number; action: string }> };
+  getChartOptions: () => ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function TipoDeepDive({
+  tipoQueData,
+  getChartData,
+  getChartOptions,
+  loading,
+}: TipoDeepDiveProps) {
+  // Get unique types that have que breakdowns
+  const types = Array.from(new Set(tipoQueData.map((d) => d.type))).sort();
+  const [selectedType, setSelectedType] = useState<string>(types[0] || "");
+
+  const chartData = getChartData(tipoQueData, selectedType);
+  const chartOptions = getChartOptions();
+
+  const typeTotal = tipoQueData
+    .filter((item) => item.type === selectedType)
+    .reduce((sum, item) => sum + Math.abs(Number(item.total)), 0);
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Explorador por Tipo</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Dentro de <span className="font-semibold">{selectedType}</span> has movido{" "}
+            {typeTotal.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+          </p>
+        </div>
+        <Select value={selectedType} onValueChange={setSelectedType}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Selecciona tipo" />
+          </SelectTrigger>
+          <SelectContent>
+            {types.map((t) => (
+              <SelectItem key={t} value={t}>
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="h-72">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : (chartData?.labels?.length ?? 0) > 0 ? (
+              <Bar data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No hay datos para este tipo
+              </div>
+            )}
+          </div>
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">
+              Desglose de categorías
+            </h4>
+            {loading ? (
+              <div className="flex items-center justify-center h-48">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : chartData.details && chartData.details.length > 0 ? (
+              <div className="space-y-2 max-h-72 overflow-y-auto">
+                {chartData.details.map((item) => {
+                  const pct = typeTotal > 0 ? (item.total / typeTotal) * 100 : 0;
+                  const isExpense = item.action === "Gasto" || item.action === "Inversión";
+                  return (
+                    <div key={item.category} className="flex items-center justify-between text-sm">
+                      <div className="flex-1 min-w-0 mr-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium truncate">{item.category}</span>
+                            <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                              isExpense
+                                ? "bg-red-100 text-red-700"
+                                : "bg-green-100 text-green-700"
+                            }`}>
+                              {item.action}
+                            </span>
+                          </div>
+                          <span className="text-muted-foreground ml-2 shrink-0">
+                            {item.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                          </span>
+                        </div>
+                        <div className="w-full bg-muted rounded-full h-2">
+                          <div
+                            className={`h-2 rounded-full transition-all ${isExpense ? "bg-red-400" : "bg-green-400"}`}
+                            style={{ width: `${Math.min(pct, 100)}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between mt-0.5">
+                          <span className="text-xs text-muted-foreground">{pct.toFixed(1)}%</span>
+                          <span className="text-xs text-muted-foreground">{item.count} mov.</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+                No hay datos de categorías para este tipo
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/TipoExplorer.tsx
+++ b/components/analytics/TipoExplorer.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { TipoQueDatum } from "@/lib/analytics-charts";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface TipoExplorerProps {
+  tipoQueData: TipoQueDatum[];
+  types: string[];
+  getChartData: (data: TipoQueDatum[], type: string) => ChartData<'bar', number[], string> & { details?: Array<{ category: string; total: number; count: number; action: string }>; total?: number };
+  getChartOptions: () => ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function TipoExplorer({
+  tipoQueData,
+  types,
+  getChartData,
+  getChartOptions,
+  loading,
+}: TipoExplorerProps) {
+  const [selectedTipo, setSelectedTipo] = useState<string>(types[0] || "");
+
+  const chartData = getChartData(tipoQueData, selectedTipo);
+  const chartOptions = getChartOptions();
+
+  const tipoTotal = chartData.total || 0;
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Explorador por Tipo</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Dentro de <span className="font-semibold">{selectedTipo}</span> has movido{" "}
+            {tipoTotal.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+          </p>
+        </div>
+        <Select value={selectedTipo} onValueChange={setSelectedTipo}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Selecciona tipo" />
+          </SelectTrigger>
+          <SelectContent className="max-h-[300px]">
+            {types.map((t) => (
+              <SelectItem key={t} value={t}>
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="h-72">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : (chartData?.labels?.length ?? 0) > 0 ? (
+              <Bar data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                No hay datos para este tipo
+              </div>
+            )}
+          </div>
+          <div className="space-y-3">
+            <h4 className="text-sm font-medium text-muted-foreground">
+              Desglose de categorías (que)
+            </h4>
+            {loading ? (
+              <div className="flex items-center justify-center h-48">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : chartData.details && chartData.details.length > 0 ? (
+              <div className="space-y-2 max-h-72 overflow-y-auto">
+                {chartData.details.map((item) => {
+                  const pct = tipoTotal > 0 ? (item.total / tipoTotal) * 100 : 0;
+                  const isExpense = item.action === "Gasto" || item.action === "Inversión";
+                  return (
+                    <div key={item.category} className="flex items-center justify-between text-sm">
+                      <div className="flex-1 min-w-0 mr-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium truncate">{item.category}</span>
+                            <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                              isExpense
+                                ? "bg-red-100 text-red-700"
+                                : "bg-green-100 text-green-700"
+                            }`}>
+                              {item.action}
+                            </span>
+                          </div>
+                          <span className="text-muted-foreground ml-2 shrink-0">
+                            {item.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                          </span>
+                        </div>
+                        <div className="w-full bg-muted rounded-full h-2">
+                          <div
+                            className={`h-2 rounded-full transition-all ${isExpense ? "bg-red-400" : "bg-green-400"}`}
+                            style={{ width: `${Math.min(pct, 100)}%` }}
+                          />
+                        </div>
+                        <div className="flex justify-between mt-0.5">
+                          <span className="text-xs text-muted-foreground">{pct.toFixed(1)}%</span>
+                          <span className="text-xs text-muted-foreground">{item.count} mov.</span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+                No hay datos de categorías para este tipo
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/TopTransactionsTable.tsx
+++ b/components/analytics/TopTransactionsTable.tsx
@@ -1,0 +1,103 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { TopTransactionDatum } from "@/lib/analytics-charts";
+import { TrendingUp, TrendingDown } from "lucide-react";
+
+interface TopTransactionsTableProps {
+  transactions: TopTransactionDatum[];
+  loading: boolean;
+}
+
+export function TopTransactionsTable({ transactions, loading }: TopTransactionsTableProps) {
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader>
+        <CardTitle>Mayores Movimientos</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center justify-center h-48">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : transactions.length > 0 ? (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[100px]">Fecha</TableHead>
+                  <TableHead>Categoría</TableHead>
+                  <TableHead>Tipo</TableHead>
+                  <TableHead>Plataforma</TableHead>
+                  <TableHead className="text-right">Importe</TableHead>
+                  <TableHead className="hidden sm:table-cell">Detalle</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {transactions.map((tx) => {
+                  const isIncome = tx.action === "Ingreso";
+                  const isInvestment = tx.action === "Inversión";
+                  const amount = Math.abs(Number(tx.amount));
+                  return (
+                    <TableRow key={tx.id}>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {new Date(tx.fecha).toLocaleDateString("es-ES")}
+                      </TableCell>
+                      <TableCell className="font-medium">{tx.category}</TableCell>
+                      <TableCell>
+                        <span
+                          className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${
+                            isIncome
+                              ? "bg-green-100 text-green-700"
+                              : isInvestment
+                              ? "bg-blue-100 text-blue-700"
+                              : "bg-red-100 text-red-700"
+                          }`}
+                        >
+                          {isIncome ? (
+                            <TrendingUp className="h-3 w-3" />
+                          ) : (
+                            <TrendingDown className="h-3 w-3" />
+                          )}
+                          {tx.action}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {tx.platform}
+                      </TableCell>
+                      <TableCell
+                        className={`text-right font-semibold ${
+                          isIncome
+                            ? "text-green-600"
+                            : isInvestment
+                            ? "text-blue-600"
+                            : "text-destructive"
+                        }`}
+                      >
+                        {isIncome ? "+" : "-"}
+                        {amount.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell text-sm text-muted-foreground max-w-[200px] truncate">
+                        {tx.detalle1 || tx.detalle2 || "—"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center h-48 text-muted-foreground">
+            No hay transacciones disponibles
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/TrendExplorer.tsx
+++ b/components/analytics/TrendExplorer.tsx
@@ -58,7 +58,7 @@ export function TrendExplorer({
   getLineChartOptions,
 }: TrendExplorerProps) {
   const [selectedTipo, setSelectedTipo] = useState<string>("");
-  const [selectedQue, setSelectedQue] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("__all__");
 
   // Build tipo → que mapping
   const tipoToQueMap = useMemo(() => {
@@ -77,12 +77,12 @@ export function TrendExplorer({
 
   const handleTipoChange = (tipo: string) => {
     setSelectedTipo(tipo);
-    setSelectedQue("");
+    setSelectedQue("__all__");
   };
 
   // Determine what chart data to show
-  const isTipoOnly = selectedTipo && !selectedQue;
-  const isQue = !!selectedQue;
+  const isTipoOnly = selectedTipo && selectedQue === "__all__";
+  const isQue = selectedTipo && selectedQue !== "__all__";
 
   const chartData = isTipoOnly
     ? getTipoTrendData(typeTemporalData, selectedTipo, groupBy)
@@ -159,7 +159,7 @@ export function TrendExplorer({
               <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
             </SelectTrigger>
             <SelectContent className="max-h-[300px]">
-              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              <SelectItem value="__all__">Todas (ver tipo agregado)</SelectItem>
               {availableQue.map((q) => (
                 <SelectItem key={q} value={q}>
                   {q}

--- a/components/analytics/TrendExplorer.tsx
+++ b/components/analytics/TrendExplorer.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Line } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { CategoryTemporalDatum, TypeTemporalDatum, TipoQueDatum } from "@/lib/analytics-charts";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface TrendExplorerProps {
+  categoryTemporalData: CategoryTemporalDatum[];
+  typeTemporalData: TypeTemporalDatum[];
+  tipoQueData: TipoQueDatum[];
+  types: string[];
+  groupBy: "month" | "year";
+  loading: boolean;
+  getCategoryTrendData: (
+    data: CategoryTemporalDatum[],
+    category: string,
+    groupBy: "month" | "year",
+  ) => ChartData<'line', number[], string> & { counts?: number[]; trendSlope?: number };
+  getTipoTrendData: (
+    data: TypeTemporalDatum[],
+    type: string,
+    groupBy: "month" | "year",
+  ) => ChartData<'line', number[], string> & { counts?: number[]; trendSlope?: number };
+  getLineChartOptions: () => ChartOptions<'line'>;
+}
+
+export function TrendExplorer({
+  categoryTemporalData,
+  typeTemporalData,
+  tipoQueData,
+  types,
+  groupBy,
+  loading,
+  getCategoryTrendData,
+  getTipoTrendData,
+  getLineChartOptions,
+}: TrendExplorerProps) {
+  const [selectedTipo, setSelectedTipo] = useState<string>("");
+  const [selectedQue, setSelectedQue] = useState<string>("");
+
+  // Build tipo → que mapping
+  const tipoToQueMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const item of tipoQueData) {
+      if (!map.has(item.type)) map.set(item.type, new Set());
+      map.get(item.type)!.add(item.category);
+    }
+    return map;
+  }, [tipoQueData]);
+
+  // Available que options based on selected tipo
+  const availableQue = selectedTipo && tipoToQueMap.has(selectedTipo)
+    ? Array.from(tipoToQueMap.get(selectedTipo)!).sort()
+    : [];
+
+  const handleTipoChange = (tipo: string) => {
+    setSelectedTipo(tipo);
+    setSelectedQue("");
+  };
+
+  // Determine what chart data to show
+  const isTipoOnly = selectedTipo && !selectedQue;
+  const isQue = !!selectedQue;
+
+  const chartData = isTipoOnly
+    ? getTipoTrendData(typeTemporalData, selectedTipo, groupBy)
+    : isQue
+    ? getCategoryTrendData(categoryTemporalData, selectedQue, groupBy)
+    : null;
+
+  const chartOptions = getLineChartOptions();
+
+  const trendSlope = chartData?.trendSlope || 0;
+  const trendDirection =
+    trendSlope > 0.5 ? "up" : trendSlope < -0.5 ? "down" : "flat";
+
+  // Compute stats
+  let totalSpend = 0;
+  let dataPoints = 0;
+  let avgPerPeriod = 0;
+
+  if (isTipoOnly) {
+    const tipoData = typeTemporalData.filter(
+      (d) => d.type === selectedTipo && d.action === "Gasto",
+    );
+    totalSpend = tipoData.reduce((sum, d) => sum + Math.abs(Number(d.total)), 0);
+    dataPoints = tipoData.length;
+    avgPerPeriod = dataPoints > 0 ? totalSpend / dataPoints : 0;
+  } else if (isQue) {
+    const queData = categoryTemporalData.filter(
+      (d) => d.category === selectedQue && d.action === "Gasto",
+    );
+    totalSpend = queData.reduce((sum, d) => sum + Math.abs(Number(d.total)), 0);
+    dataPoints = queData.length;
+    avgPerPeriod = dataPoints > 0 ? totalSpend / dataPoints : 0;
+  }
+
+  // Que breakdown for sub-table when tipo is selected
+  const queBreakdown = isTipoOnly
+    ? tipoQueData
+        .filter((d) => d.type === selectedTipo)
+        .map((d) => ({
+          category: d.category,
+          total: Math.abs(Number(d.total)),
+          count: d.count || 0,
+          action: d.action,
+        }))
+        .sort((a, b) => b.total - a.total)
+    : [];
+
+  const tipoTotal = queBreakdown.reduce((sum, d) => sum + d.total, 0);
+
+  return (
+    <Card className="col-span-1 lg:col-span-2">
+      <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <CardTitle>Tendencias</CardTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Evolución temporal de {selectedQue || selectedTipo || "todas las categorías"}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Select value={selectedTipo} onValueChange={handleTipoChange}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder="Tipo (general)" />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              {types.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={selectedQue} onValueChange={setSelectedQue} disabled={!selectedTipo}>
+            <SelectTrigger className="w-[180px]">
+              <SelectValue placeholder={selectedTipo ? "Categoría (específica)" : "Selecciona tipo primero"} />
+            </SelectTrigger>
+            <SelectContent className="max-h-[300px]">
+              <SelectItem value="">Todas (ver tipo agregado)</SelectItem>
+              {availableQue.map((q) => (
+                <SelectItem key={q} value={q}>
+                  {q}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+          <div className="lg:col-span-3 h-80">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+              </div>
+            ) : chartData && (chartData?.labels?.length ?? 0) > 0 ? (
+              <Line data={chartData} options={chartOptions} />
+            ) : (
+              <div className="flex items-center justify-center h-full text-muted-foreground">
+                Selecciona un tipo o categoría para ver la tendencia
+              </div>
+            )}
+          </div>
+          <div className="space-y-4">
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Tendencia</div>
+              <div className="flex items-center gap-2">
+                {trendDirection === "up" ? (
+                  <>
+                    <TrendingUp className="h-5 w-5 text-red-500" />
+                    <span className="text-lg font-bold text-red-500">Subiendo</span>
+                  </>
+                ) : trendDirection === "down" ? (
+                  <>
+                    <TrendingDown className="h-5 w-5 text-green-500" />
+                    <span className="text-lg font-bold text-green-500">Bajando</span>
+                  </>
+                ) : (
+                  <>
+                    <Minus className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-lg font-bold text-muted-foreground">Estable</span>
+                  </>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {trendSlope > 0 ? "+" : ""}
+                {trendSlope.toFixed(0)} €/{groupBy === "year" ? "año" : "mes"} de media
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Total gastado</div>
+              <div className="text-xl font-bold">
+                {totalSpend.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">
+                Media por {groupBy === "year" ? "año" : "mes"}
+              </div>
+              <div className="text-xl font-bold">
+                {avgPerPeriod.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-muted/50">
+              <div className="text-sm text-muted-foreground mb-1">Periodos con datos</div>
+              <div className="text-xl font-bold">{dataPoints}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Sub-table: que breakdown when tipo is selected */}
+        {isTipoOnly && queBreakdown.length > 0 && (
+          <div className="mt-6 border-t pt-6">
+            <h4 className="text-sm font-medium text-muted-foreground mb-3">
+              Desglose de categorías dentro de {selectedTipo}
+            </h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {queBreakdown.map((item) => {
+                const pct = tipoTotal > 0 ? (item.total / tipoTotal) * 100 : 0;
+                const isExpense = item.action === "Gasto" || item.action === "Inversión";
+                return (
+                  <div key={item.category} className="p-3 rounded-lg border">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-medium text-sm">{item.category}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                        isExpense ? "bg-red-100 text-red-700" : "bg-green-100 text-green-700"
+                      }`}>
+                        {item.action}
+                      </span>
+                    </div>
+                    <div className="text-lg font-bold">
+                      {item.total.toLocaleString("es-ES", { style: "currency", currency: "EUR" })}
+                    </div>
+                    <div className="w-full bg-muted rounded-full h-2 mt-2">
+                      <div
+                        className={`h-2 rounded-full ${isExpense ? "bg-red-400" : "bg-green-400"}`}
+                        style={{ width: `${Math.min(pct, 100)}%` }}
+                      />
+                    </div>
+                    <div className="flex justify-between mt-1">
+                      <span className="text-xs text-muted-foreground">{pct.toFixed(1)}%</span>
+                      <span className="text-xs text-muted-foreground">{item.count} mov.</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/analytics/TypeChart.tsx
+++ b/components/analytics/TypeChart.tsx
@@ -1,0 +1,51 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Bar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+// Register Chart.js components
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+interface TypeChartProps {
+  data: ChartData<'bar', number[], string>;
+  options: ChartOptions<'bar'>;
+  loading: boolean;
+}
+
+export function TypeChart({ data, options, loading }: TypeChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Gasto por Tipo</CardTitle>
+      </CardHeader>
+      <CardContent className="h-80">
+        {loading ? (
+          <div className="flex items-center justify-center h-full">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+          </div>
+        ) : (data?.labels?.length ?? 0) > 0 ? (
+          <Bar data={data} options={options} />
+        ) : (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            No hay datos disponibles
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/use-analytics-data.ts
+++ b/hooks/use-analytics-data.ts
@@ -7,6 +7,9 @@ import {
   TypeDatum,
   TopTransactionDatum,
   CategoryPlatformDatum,
+  TipoQueDatum,
+  CategoryTemporalDatum,
+  CategoryStatDatum,
 } from "@/lib/analytics-charts";
 
 interface AnalyticsMetrics {
@@ -21,6 +24,9 @@ export interface AnalyticsData {
   typeData: TypeDatum[];
   topTransactions: TopTransactionDatum[];
   categoryPlatformData: CategoryPlatformDatum[];
+  tipoQueData: TipoQueDatum[];
+  categoryTemporalData: CategoryTemporalDatum[];
+  categoryStats: CategoryStatDatum[];
   sums: {
     gastos: number;
     ingresos: number;
@@ -54,6 +60,9 @@ export function useAnalyticsData() {
     typeData: [],
     topTransactions: [],
     categoryPlatformData: [],
+    tipoQueData: [],
+    categoryTemporalData: [],
+    categoryStats: [],
     sums: { gastos: 0, ingresos: 0, inversion: 0 },
     metrics: undefined,
     netTemporal: [],

--- a/hooks/use-analytics-data.ts
+++ b/hooks/use-analytics-data.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
-import { CategoryDatum, TemporalDatum } from "@/lib/analytics-charts";
+import {
+  CategoryDatum,
+  TemporalDatum,
+  PlatformDatum,
+  TypeDatum,
+  TopTransactionDatum,
+  CategoryPlatformDatum,
+} from "@/lib/analytics-charts";
 
 interface AnalyticsMetrics {
   groupBy?: "month" | "year";
@@ -10,6 +17,10 @@ interface AnalyticsMetrics {
 export interface AnalyticsData {
   temporalData: TemporalDatum[];
   categoryData: CategoryDatum[];
+  platformData: PlatformDatum[];
+  typeData: TypeDatum[];
+  topTransactions: TopTransactionDatum[];
+  categoryPlatformData: CategoryPlatformDatum[];
   sums: {
     gastos: number;
     ingresos: number;
@@ -39,6 +50,10 @@ export function useAnalyticsData() {
   const [data, setData] = useState<AnalyticsData>({
     temporalData: [],
     categoryData: [],
+    platformData: [],
+    typeData: [],
+    topTransactions: [],
+    categoryPlatformData: [],
     sums: { gastos: 0, ingresos: 0, inversion: 0 },
     metrics: undefined,
     netTemporal: [],

--- a/hooks/use-analytics-data.ts
+++ b/hooks/use-analytics-data.ts
@@ -9,6 +9,7 @@ import {
   CategoryPlatformDatum,
   TipoQueDatum,
   CategoryTemporalDatum,
+  TypeTemporalDatum,
   CategoryStatDatum,
 } from "@/lib/analytics-charts";
 
@@ -26,6 +27,7 @@ export interface AnalyticsData {
   categoryPlatformData: CategoryPlatformDatum[];
   tipoQueData: TipoQueDatum[];
   categoryTemporalData: CategoryTemporalDatum[];
+  typeTemporalData: TypeTemporalDatum[];
   categoryStats: CategoryStatDatum[];
   sums: {
     gastos: number;
@@ -62,6 +64,7 @@ export function useAnalyticsData() {
     categoryPlatformData: [],
     tipoQueData: [],
     categoryTemporalData: [],
+    typeTemporalData: [],
     categoryStats: [],
     sums: { gastos: 0, ingresos: 0, inversion: 0 },
     metrics: undefined,

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -3,6 +3,7 @@
 import { createClient, createPool } from "@vercel/postgres";
 import { revalidatePath } from "next/cache";
 import { v4 as uuidv4 } from "uuid";
+import { escapeLikePattern } from "./utils";
 
 interface EntryFilter {
   search?: string;
@@ -243,7 +244,7 @@ export async function getEntries(
           quien ILIKE $${paramIndex}
         )`
       );
-      params.push(`%${search}%`);
+      params.push(`%${escapeLikePattern(search)}%`);
       paramIndex++;
     }
 

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,78 +1,50 @@
 "use server";
 
-import { createClient, createPool } from "@vercel/postgres";
+/**
+ * Server-action surface for the finance domain.
+ *
+ * This file used to contain ~415 lines of mixed user CRUD, entry
+ * mutations, and pagination logic. The implementation has been moved
+ * into focused repository modules (`lib/users/repo.ts`,
+ * `lib/entries/repo.ts`). This file now provides only the
+ * `"use server"` boundary that client components and API routes rely
+ * on — its job is to be the small, audited surface that performs the
+ * RPC handshake.
+ *
+ * Public API stays identical, so existing imports (`@/lib/actions`)
+ * keep working:
+ *   - createUser, getUserByEmail
+ *   - createEntry, updateEntry, deleteEntry, deleteManyEntries
+ *   - getEntries, getExportEntries
+ */
+
 import { revalidatePath } from "next/cache";
-import { v4 as uuidv4 } from "uuid";
-import { escapeLikePattern } from "./utils";
-
-interface EntryFilter {
-  search?: string;
-  accion?: string;
-  tipo?: string;
-  from?: string;
-  to?: string;
-  page: number;
-  itemsPerPage: number;
-  sortBy?: string;
-  sortOrder?: string;
-}
-
-interface Entry {
-  id: string;
-  fecha: string;
-  tipo: string;
-  accion: string;
-  que: string;
-  plataforma_pago: string;
-  cantidad: number;
-  detalle1?: string;
-  detalle2?: string;
-  quien?: string;
-}
-
-interface PaginatedEntries {
-  entries: Entry[];
-  total: number;
-  totalPages: number;
-}
+import { findUserByEmail, insertUser } from "@/lib/users/repo";
+import {
+  deleteEntriesByIds,
+  deleteEntryById,
+  exportEntries,
+  findEntries,
+  insertEntry,
+  updateEntryById,
+  type EntryFilter,
+  type EntryInput,
+  type PaginatedEntries,
+} from "@/lib/entries/repo";
 
 export async function createUser(formData: { name: string; email: string }) {
-  const id = uuidv4();
   try {
-    const client = createClient();
-    await client.connect();
-
-    try {
-      await client.sql`
-        INSERT INTO users (id, name, email)
-        VALUES (${id}, ${formData.name}, ${formData.email})
-      `;
-    } finally {
-      await client.end();
-    }
+    await insertUser(formData);
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to create user.");
   }
-
   revalidatePath("/");
 }
 
 export async function getUserByEmail(email: string) {
   try {
-    const client = createClient();
-    await client.connect();
-
-    try {
-      const result = await client.sql`
-        SELECT id, name, email
-        FROM users
-        WHERE email = ${email}
-      `;
-      return result.rows[0];
-    } finally {
-      await client.end();
-    }
+    return await findUserByEmail(email);
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to get user.");
@@ -80,109 +52,29 @@ export async function getUserByEmail(email: string) {
 }
 
 export async function createEntry(
-  formData: {
-    fecha: string;
-    tipo: string;
-    accion: string;
-    que: string;
-    plataforma_pago: string;
-    cantidad: number;
-    detalle1?: string;
-    detalle2?: string;
-    quien?: string;
-  },
+  formData: EntryInput,
   session: { user: { id: string } }
 ) {
-  const entryId = uuidv4();
-  const {
-    fecha,
-    tipo,
-    accion,
-    que,
-    plataforma_pago,
-    cantidad,
-    detalle1,
-    detalle2,
-    quien,
-  } = formData;
-
   try {
-    const client = createClient();
-    await client.connect();
-
-    try {
-      await client.sql`
-        INSERT INTO finance_entries (id, fecha, tipo, accion, que, plataforma_pago, cantidad, detalle1, detalle2, quien, user_id)
-        VALUES (${entryId}, ${fecha}::timestamptz, ${tipo}, ${accion}, ${que}, ${plataforma_pago}, ${cantidad}, ${
-        detalle1 || null
-      }, ${detalle2 || null}, ${quien || 'Yo'}, ${session.user.id})
-      `;
-    } finally {
-      await client.end();
-    }
+    await insertEntry(formData, session.user.id);
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to create entry.");
   }
-
   revalidatePath("/");
 }
 
 export async function updateEntry(
   entryId: string,
-  formData: {
-    fecha: string;
-    tipo: string;
-    accion: string;
-    que: string;
-    plataforma_pago: string;
-    cantidad: number;
-    detalle1?: string;
-    detalle2?: string;
-    quien?: string;
-  },
+  formData: EntryInput,
   session: { user: { id: string } }
 ) {
-  const {
-    fecha,
-    tipo,
-    accion,
-    que,
-    plataforma_pago,
-    cantidad,
-    detalle1,
-    detalle2,
-    quien,
-  } = formData;
-
   try {
-    const client = createClient();
-    await client.connect();
-
-    try {
-      await client.sql`
-        UPDATE finance_entries
-        SET fecha = ${fecha}::timestamptz,
-            tipo = ${tipo},
-            accion = ${accion},
-            que = ${que},
-            plataforma_pago = ${plataforma_pago},
-            cantidad = ${cantidad},
-            detalle1 = ${detalle1 || null},
-            detalle2 = ${detalle2 || null},
-            quien = ${quien || 'Yo'},
-            updated_at = NOW()
-        WHERE id = ${entryId}
-          AND user_id = ${session.user.id}
-      `;
-    } finally {
-      await client.end();
-    }
+    await updateEntryById(entryId, formData, session.user.id);
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to update entry.");
   }
-
   revalidatePath("/");
 }
 
@@ -190,226 +82,36 @@ export async function deleteEntry(
   formData: FormData,
   session: { user: { id: string } }
 ) {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    await client.sql`
-      DELETE FROM finance_entries
-      WHERE id = ${String(formData.get("entryId"))}
-      AND user_id = ${session.user.id}
-    `;
-    revalidatePath("/");
-  } finally {
-    await client.end();
-  }
-}
-
-export async function getEntries(
-  filters: EntryFilter,
-  session: { user: { id: string } }
-): Promise<PaginatedEntries> {
-  console.log("Getting entries with filters:", filters);
-  const userId = String(session.user.id);
-  const {
-    search,
-    accion,
-    tipo,
-    from,
-    to,
-    page,
-    itemsPerPage,
-    sortBy,
-    sortOrder,
-  } = filters;
-  const offset = (page - 1) * itemsPerPage;
-
-  const pool = createPool();
-
-  try {
-    console.log("Getting entries with filters:", filters);
-    const whereClauses: string[] = [];
-    const params: (string | number)[] = [];
-    let paramIndex = 1;
-
-    if (search) {
-      whereClauses.push(
-        `(
-          accion ILIKE $${paramIndex} OR
-          que ILIKE $${paramIndex} OR
-          tipo ILIKE $${paramIndex} OR
-          plataforma_pago ILIKE $${paramIndex} OR
-          detalle1 ILIKE $${paramIndex} OR
-          detalle2 ILIKE $${paramIndex} OR
-          quien ILIKE $${paramIndex}
-        )`
-      );
-      params.push(`%${escapeLikePattern(search)}%`);
-      paramIndex++;
-    }
-
-    if (accion && accion !== "todos") {
-      whereClauses.push(`accion = $${paramIndex}`);
-      params.push(accion);
-      paramIndex++;
-    }
-
-    if (tipo && tipo !== "todos") {
-      whereClauses.push(`tipo = $${paramIndex}`);
-      params.push(tipo);
-      paramIndex++;
-    }
-
-    if (from) {
-      whereClauses.push(
-        `fecha >= ($${paramIndex} || 'T00:00:00.000')::timestamptz`
-      );
-      params.push(from);
-      paramIndex++;
-    }
-
-    if (to) {
-      whereClauses.push(
-        `fecha <= ($${paramIndex} || 'T23:59:59.999')::timestamptz`
-      );
-      params.push(to);
-      paramIndex++;
-    }
-
-    whereClauses.push(`user_id = $${paramIndex}`);
-    params.push(userId);
-    paramIndex++;
-
-    const whereStatment =
-      whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
-    console.log("Final WHERE clause:", whereStatment, params);
-
-    const countQuery = `SELECT COUNT(*)::int AS count FROM finance_entries ${whereStatment}`;
-    const countResult = await pool.query(countQuery, params);
-    const total = countResult.rows[0]?.count ?? 0;
-
-    // Build the entries query with parameters
-    const allowedSortFields = new Set([
-      "fecha",
-      "accion",
-      "que",
-      "tipo",
-      "plataforma_pago",
-      "cantidad",
-      "quien",
-    ]);
-    const sortField =
-      sortBy && allowedSortFields.has(String(sortBy))
-        ? String(sortBy)
-        : "fecha";
-    const sortDirection =
-      String(sortOrder)?.toLowerCase() === "asc" ? "ASC" : "DESC";
-
-    const entriesQuery = `SELECT id, fecha, tipo, accion, que, plataforma_pago, cantidad, detalle1, detalle2, quien, user_id
-      FROM finance_entries
-      ${whereStatment}
-      ORDER BY ${sortField} ${sortDirection}
-      LIMIT $${params.length + 1}
-      OFFSET $${params.length + 2}
-    `;
-    const entriesResult = await pool.query(entriesQuery, [
-      ...params,
-      itemsPerPage,
-      offset,
-    ]);
-    // console.log('entriesResult', entriesResult)
-    const entries = entriesResult.rows as Entry[];
-    const totalPages = Math.ceil((total || 0) / itemsPerPage);
-    // console.log('entries', entries)
-    return {
-      entries,
-      total,
-      totalPages,
-    };
-  } finally {
-    await pool.end();
-  }
+  const entryId = String(formData.get("entryId") ?? "");
+  if (!entryId) return;
+  await deleteEntryById(entryId, session.user.id);
+  revalidatePath("/");
 }
 
 export async function deleteManyEntries(
   formData: FormData,
   session: { user: { id: string } }
 ) {
-  const raw = String(formData.get("ids") || "");
+  const raw = String(formData.get("ids") ?? "");
   const ids = raw
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
-  for (const id of ids) {
-    const fd = new FormData();
-    fd.set("entryId", id);
-    await deleteEntry(fd, session);
-  }
+  if (ids.length === 0) return;
+  await deleteEntriesByIds(ids, session.user.id);
   revalidatePath("/");
 }
 
-// Get entries for export (with filters)
+export async function getEntries(
+  filters: EntryFilter,
+  session: { user: { id: string } }
+): Promise<PaginatedEntries> {
+  return findEntries(filters, session.user.id);
+}
+
 export async function getExportEntries(
-  { search = "", tipo = "", from = "", to = "" },
+  filter: { search?: string; tipo?: string; from?: string; to?: string },
   userId: string
 ) {
-  const whereClause = [];
-  const params = [];
-  let paramIndex = 1;
-
-  if (search) {
-    whereClause.push(`(
-      accion ILIKE $${paramIndex} OR 
-      que ILIKE $${paramIndex} OR 
-      plataforma_pago ILIKE $${paramIndex} OR
-      detalle1 ILIKE $${paramIndex} OR
-      detalle2 ILIKE $${paramIndex} OR
-      quien ILIKE $${paramIndex}
-    )`);
-    params.push(`%${search}%`);
-    paramIndex++;
-  }
-
-  if (tipo) {
-    whereClause.push(`tipo = $${paramIndex}`);
-    params.push(tipo);
-    paramIndex++;
-  }
-
-  if (from) {
-    whereClause.push(
-      `fecha >= ($${paramIndex} || 'T00:00:00.000')::timestamptz`
-    );
-    params.push(from);
-    paramIndex++;
-  }
-
-  if (to) {
-    whereClause.push(
-      `fecha <= ($${paramIndex} || 'T23:59:59.999')::timestamptz`
-    );
-    params.push(to);
-    paramIndex++;
-  }
-
-  // Always filter by user
-  whereClause.push(`user_id = $${paramIndex}`);
-  params.push(userId);
-
-  const whereStatement =
-    whereClause.length > 0 ? `WHERE ${whereClause.join(" AND ")}` : "";
-
-  const client = createClient();
-  await client.connect();
-  try {
-    const query = `
-      SELECT * FROM finance_entries 
-      ${whereStatement}
-      ORDER BY fecha DESC
-    `;
-    const result = await client.query(query, params);
-    return result.rows;
-  } finally {
-    await client.end();
-  }
+  return exportEntries(filter, userId);
 }

--- a/lib/analytics-charts.ts
+++ b/lib/analytics-charts.ts
@@ -54,6 +54,31 @@ export interface CategoryPlatformDatum {
   count?: number;
 }
 
+export interface TipoQueDatum {
+  type: string;
+  category: string;
+  action: string;
+  total: number;
+  count?: number;
+}
+
+export interface CategoryTemporalDatum {
+  period: string;
+  category: string;
+  action: string;
+  total: number;
+  count?: number;
+}
+
+export interface CategoryStatDatum {
+  category: string;
+  action: string;
+  avg: number;
+  min: number;
+  max: number;
+  count: number;
+}
+
 export interface AnalyticsDataset {
   temporalData: TemporalDatum[];
   categoryData: CategoryDatum[];
@@ -61,6 +86,9 @@ export interface AnalyticsDataset {
   typeData: TypeDatum[];
   topTransactions: TopTransactionDatum[];
   categoryPlatformData: CategoryPlatformDatum[];
+  tipoQueData: TipoQueDatum[];
+  categoryTemporalData: CategoryTemporalDatum[];
+  categoryStats: CategoryStatDatum[];
 }
 
 const actionColorMap: Record<string, { background: string; border: string }> = {
@@ -455,6 +483,331 @@ export function getCategoryPlatformBreakdown(
 }
 
 export function getCategoryPlatformChartOptions(): ChartOptions<"bar"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+// ─── TIPO × QUE BREAKDOWN ───
+
+export function getTipoQueBreakdown(
+  tipoQueData: TipoQueDatum[],
+  selectedType: string,
+) {
+  const filtered = tipoQueData.filter((item) => item.type === selectedType);
+
+  const sorted = filtered
+    .map((item) => ({
+      category: item.category,
+      total: Math.abs(Number(item.total)),
+      count: Number(item.count || 0),
+      action: item.action,
+    }))
+    .sort((a, b) => b.total - a.total);
+
+  const colors = [
+    "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
+    "#FF9F40", "#8AC24A", "#FF5252", "#607D8B", "#9C27B0",
+    "#3F51B5", "#E91E63",
+  ];
+
+  return {
+    labels: sorted.map((item) => item.category),
+    datasets: [
+      {
+        label: "Total",
+        data: sorted.map((item) => item.total),
+        backgroundColor: sorted.map((_, index) => colors[index % colors.length]),
+        borderWidth: 1,
+      },
+    ],
+    details: sorted,
+  };
+}
+
+export function getTipoQueChartOptions(): ChartOptions<"bar"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+// ─── CATEGORY TREND TRACKER ───
+
+export function getCategoryTrendData(
+  categoryTemporalData: CategoryTemporalDatum[],
+  selectedCategory: string,
+  groupBy: "month" | "year",
+) {
+  const filtered = categoryTemporalData.filter(
+    (item) => item.category === selectedCategory,
+  );
+
+  const periods = Array.from(
+    new Set(filtered.map((item) => item.period)),
+  ).sort();
+
+  const gastos = periods.map((period) => {
+    const item = filtered.find(
+      (d) => d.period === period && d.action === "Gasto",
+    );
+    return item ? Math.abs(Number(item.total)) : 0;
+  });
+
+  const ingresos = periods.map((period) => {
+    const item = filtered.find(
+      (d) => d.period === period && d.action === "Ingreso",
+    );
+    return item ? Math.abs(Number(item.total)) : 0;
+  });
+
+  const counts = periods.map((period) => {
+    return filtered
+      .filter((d) => d.period === period)
+      .reduce((sum, d) => sum + (d.count || 0), 0);
+  });
+
+  // Simple linear regression on gastos to show trend
+  const n = gastos.length;
+  let trendSlope = 0;
+  if (n > 1) {
+    const sumX = gastos.reduce((sum, _, i) => sum + i, 0);
+    const sumY = gastos.reduce((sum, v) => sum + v, 0);
+    const sumXY = gastos.reduce((sum, v, i) => sum + i * v, 0);
+    const sumXX = gastos.reduce((sum, _, i) => sum + i * i, 0);
+    trendSlope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  }
+
+  // Trend line data
+  const trendLine = gastos.map((_, i) => {
+    const sumY = gastos.reduce((sum, v) => sum + v, 0);
+    const avgY = sumY / n;
+    return avgY + trendSlope * (i - (n - 1) / 2);
+  });
+
+  return {
+    labels: periods.map((p) => {
+      const d = new Date(p as string);
+      return groupBy === "year"
+        ? format(d, "yyyy", { locale: es })
+        : format(d, "MMM yyyy", { locale: es });
+    }),
+    datasets: [
+      {
+        label: "Gasto",
+        data: gastos,
+        borderColor: "rgba(239, 68, 68, 1)",
+        backgroundColor: "rgba(239, 68, 68, 0.1)",
+        fill: true,
+        tension: 0.3,
+      },
+      {
+        label: "Ingreso",
+        data: ingresos,
+        borderColor: "rgba(34, 197, 94, 1)",
+        backgroundColor: "rgba(34, 197, 94, 0.1)",
+        fill: true,
+        tension: 0.3,
+      },
+      {
+        label: "Tendencia",
+        data: trendLine,
+        borderColor: "rgba(168, 85, 247, 1)",
+        backgroundColor: "rgba(168, 85, 247, 0)",
+        borderDash: [6, 3],
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: false,
+      },
+    ],
+    counts,
+    trendSlope,
+  };
+}
+
+export function getCategoryTrendChartOptions(): ChartOptions<"line"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: "top" },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+// ─── SPENDING VELOCITY (MoM change) ───
+
+export interface VelocityItem {
+  category: string;
+  current: number;
+  previous: number;
+  change: number;
+  changePercent: number;
+  direction: "up" | "down" | "flat";
+}
+
+export function computeSpendingVelocity(
+  categoryTemporalData: CategoryTemporalDatum[],
+  action: string = "Gasto",
+): VelocityItem[] {
+  const filtered = categoryTemporalData.filter((item) => item.action === action);
+
+  // Group by category and period
+  const byCategory = new Map<string, Map<string, number>>();
+  for (const item of filtered) {
+    if (!byCategory.has(item.category)) {
+      byCategory.set(item.category, new Map());
+    }
+    byCategory.get(item.category)!.set(item.period, Math.abs(Number(item.total)));
+  }
+
+  const velocities: VelocityItem[] = [];
+  for (const [category, periodMap] of byCategory) {
+    const periods = Array.from(periodMap.keys()).sort();
+    if (periods.length < 2) continue;
+
+    const current = periodMap.get(periods[periods.length - 1]) || 0;
+    const previous = periodMap.get(periods[periods.length - 2]) || 0;
+
+    const change = current - previous;
+    const changePercent = previous > 0 ? (change / previous) * 100 : 0;
+
+    velocities.push({
+      category,
+      current,
+      previous,
+      change,
+      changePercent,
+      direction: change > 0.01 ? "up" : change < -0.01 ? "down" : "flat",
+    });
+  }
+
+  return velocities.sort((a, b) => Math.abs(b.changePercent) - Math.abs(a.changePercent));
+}
+
+// ─── SEASONAL PATTERNS ───
+
+export interface SeasonalItem {
+  month: number;
+  monthName: string;
+  total: number;
+  count: number;
+}
+
+export function getSeasonalPatterns(
+  categoryTemporalData: CategoryTemporalDatum[],
+  selectedCategory: string,
+  action: string = "Gasto",
+): SeasonalItem[] {
+  const filtered = categoryTemporalData.filter(
+    (item) => item.category === selectedCategory && item.action === action,
+  );
+
+  const monthNames = [
+    "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+    "Jul", "Ago", "Sep", "Oct", "Nov", "Dic",
+  ];
+
+  // Aggregate by calendar month across all years
+  const byMonth = new Map<number, { total: number; count: number; yearCount: number }>();
+  for (let i = 0; i < 12; i++) {
+    byMonth.set(i, { total: 0, count: 0, yearCount: 0 });
+  }
+
+  for (const item of filtered) {
+    const d = new Date(item.period);
+    const month = d.getUTCMonth();
+    const existing = byMonth.get(month)!;
+    existing.total += Math.abs(Number(item.total));
+    existing.count += item.count || 0;
+    existing.yearCount += 1;
+  }
+
+  return Array.from(byMonth.entries()).map(([month, data]) => ({
+    month,
+    monthName: monthNames[month],
+    total: data.yearCount > 0 ? data.total / data.yearCount : 0, // average per year
+    count: data.yearCount > 0 ? Math.round(data.count / data.yearCount) : 0,
+  }));
+}
+
+export function getSeasonalChartData(seasonalData: SeasonalItem[]) {
+  const colors = seasonalData.map((item) => {
+    const max = Math.max(...seasonalData.map((d) => d.total));
+    const intensity = max > 0 ? item.total / max : 0;
+    return `rgba(239, 68, 68, ${0.3 + intensity * 0.7})`;
+  });
+
+  return {
+    labels: seasonalData.map((item) => item.monthName),
+    datasets: [
+      {
+        label: "Promedio mensual",
+        data: seasonalData.map((item) => item.total),
+        backgroundColor: colors,
+        borderColor: "rgba(239, 68, 68, 0.8)",
+        borderWidth: 1,
+      },
+    ],
+  };
+}
+
+export function getSeasonalChartOptions(): ChartOptions<"bar"> {
   return {
     responsive: true,
     maintainAspectRatio: false,

--- a/lib/analytics-charts.ts
+++ b/lib/analytics-charts.ts
@@ -17,11 +17,50 @@ export interface CategoryDatum {
   count?: number;
   platform?: string | null;
   type?: string | null;
+  action?: string | null;
+}
+
+export interface PlatformDatum {
+  platform: string;
+  action: string;
+  total: number;
+  count?: number;
+}
+
+export interface TypeDatum {
+  type: string;
+  action: string;
+  total: number;
+  count?: number;
+}
+
+export interface TopTransactionDatum {
+  id: string;
+  fecha: string;
+  tipo: string;
+  action: string;
+  category: string;
+  platform: string;
+  amount: number;
+  detalle1: string | null;
+  detalle2: string | null;
+  quien: string;
+}
+
+export interface CategoryPlatformDatum {
+  category: string;
+  platform: string;
+  total: number;
+  count?: number;
 }
 
 export interface AnalyticsDataset {
   temporalData: TemporalDatum[];
   categoryData: CategoryDatum[];
+  platformData: PlatformDatum[];
+  typeData: TypeDatum[];
+  topTransactions: TopTransactionDatum[];
+  categoryPlatformData: CategoryPlatformDatum[];
 }
 
 const actionColorMap: Record<string, { background: string; border: string }> = {
@@ -249,6 +288,192 @@ export function getDoughnutChartOptions(
             const count = countsByCategory[label] || 0;
             return `${label}: ${formatEuro(value)} (${percentage}%) • ${count} mov.`;
           },
+        },
+      },
+    },
+  };
+}
+
+export function getPlatformChartData(platformData: PlatformDatum[]) {
+  // Aggregate by platform across all actions (show absolute spending)
+  const platformTotals = platformData.reduce<Record<string, { total: number; count: number }>>(
+    (acc, item) => {
+      if (!acc[item.platform]) acc[item.platform] = { total: 0, count: 0 };
+      acc[item.platform].total += Math.abs(Number(item.total));
+      acc[item.platform].count += Number(item.count || 0);
+      return acc;
+    },
+    {},
+  );
+
+  const sorted = Object.entries(platformTotals)
+    .map(([platform, { total, count }]) => ({ platform, total, count }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10); // Top 10 platforms
+
+  const colors = [
+    "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
+    "#FF9F40", "#8AC24A", "#FF5252", "#607D8B", "#9C27B0",
+  ];
+
+  return {
+    labels: sorted.map((item) => item.platform),
+    datasets: [
+      {
+        label: "Total",
+        data: sorted.map((item) => item.total),
+        backgroundColor: sorted.map((_, index) => colors[index % colors.length]),
+        borderWidth: 1,
+      },
+    ],
+    details: sorted,
+  };
+}
+
+export function getPlatformChartOptions(): ChartOptions<"bar"> {
+  return {
+    indexAxis: "y",
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+export function getTypeChartData(typeData: TypeDatum[]) {
+  // Aggregate by type across all actions
+  const typeTotals = typeData.reduce<Record<string, { total: number; count: number }>>(
+    (acc, item) => {
+      if (!acc[item.type]) acc[item.type] = { total: 0, count: 0 };
+      acc[item.type].total += Math.abs(Number(item.total));
+      acc[item.type].count += Number(item.count || 0);
+      return acc;
+    },
+    {},
+  );
+
+  const sorted = Object.entries(typeTotals)
+    .map(([type, { total, count }]) => ({ type, total, count }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 12);
+
+  const colors = [
+    "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
+    "#FF9F40", "#8AC24A", "#FF5252", "#607D8B", "#9C27B0",
+    "#3F51B5", "#E91E63",
+  ];
+
+  return {
+    labels: sorted.map((item) => item.type),
+    datasets: [
+      {
+        label: "Total",
+        data: sorted.map((item) => item.total),
+        backgroundColor: sorted.map((_, index) => colors[index % colors.length]),
+        borderWidth: 1,
+      },
+    ],
+    details: sorted,
+  };
+}
+
+export function getTypeChartOptions(): ChartOptions<"bar"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+export function getCategoryPlatformBreakdown(
+  categoryPlatformData: CategoryPlatformDatum[],
+  selectedCategory: string,
+) {
+  const filtered = categoryPlatformData.filter(
+    (item) => item.category === selectedCategory,
+  );
+
+  const sorted = filtered
+    .map((item) => ({
+      platform: item.platform,
+      total: Math.abs(Number(item.total)),
+      count: Number(item.count || 0),
+    }))
+    .sort((a, b) => b.total - a.total);
+
+  const colors = [
+    "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
+    "#FF9F40", "#8AC24A", "#FF5252", "#607D8B", "#9C27B0",
+  ];
+
+  return {
+    labels: sorted.map((item) => item.platform),
+    datasets: [
+      {
+        label: "Gasto",
+        data: sorted.map((item) => item.total),
+        backgroundColor: sorted.map((_, index) => colors[index % colors.length]),
+        borderWidth: 1,
+      },
+    ],
+    details: sorted,
+  };
+}
+
+export function getCategoryPlatformChartOptions(): ChartOptions<"bar"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
         },
       },
     },

--- a/lib/analytics-charts.ts
+++ b/lib/analytics-charts.ts
@@ -65,6 +65,15 @@ export interface TipoQueDatum {
 export interface CategoryTemporalDatum {
   period: string;
   category: string;
+  type: string;
+  action: string;
+  total: number;
+  count?: number;
+}
+
+export interface TypeTemporalDatum {
+  period: string;
+  type: string;
   action: string;
   total: number;
   count?: number;
@@ -72,6 +81,7 @@ export interface CategoryTemporalDatum {
 
 export interface CategoryStatDatum {
   category: string;
+  type: string;
   action: string;
   avg: number;
   min: number;
@@ -88,6 +98,7 @@ export interface AnalyticsDataset {
   categoryPlatformData: CategoryPlatformDatum[];
   tipoQueData: TipoQueDatum[];
   categoryTemporalData: CategoryTemporalDatum[];
+  typeTemporalData: TypeTemporalDatum[];
   categoryStats: CategoryStatDatum[];
 }
 
@@ -831,4 +842,237 @@ export function getSeasonalChartOptions(): ChartOptions<"bar"> {
       },
     },
   };
+}
+
+
+// ─── TIPO EXPLORER ───
+
+export function getTipoExplorerData(tipoQueData: TipoQueDatum[], selectedTipo: string) {
+  const filtered = tipoQueData.filter((item) => item.type === selectedTipo);
+
+  const sorted = filtered
+    .map((item) => ({
+      category: item.category,
+      total: Math.abs(Number(item.total)),
+      count: Number(item.count || 0),
+      action: item.action,
+    }))
+    .sort((a, b) => b.total - a.total);
+
+  const total = sorted.reduce((sum, item) => sum + item.total, 0);
+
+  const colors = [
+    "#FF6384", "#36A2EB", "#FFCE56", "#4BC0C0", "#9966FF",
+    "#FF9F40", "#8AC24A", "#FF5252", "#607D8B", "#9C27B0",
+    "#3F51B5", "#E91E63",
+  ];
+
+  return {
+    labels: sorted.map((item) => item.category),
+    datasets: [
+      {
+        label: "Total",
+        data: sorted.map((item) => item.total),
+        backgroundColor: sorted.map((_, index) => colors[index % colors.length]),
+        borderWidth: 1,
+      },
+    ],
+    details: sorted,
+    total,
+  };
+}
+
+export function getTipoExplorerChartOptions(): ChartOptions<"bar"> {
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const value = Number(context.raw || 0);
+            return `${context.dataset.label}: ${formatEuro(value)}`;
+          },
+        },
+      },
+    },
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => formatEuro(Number(value)),
+        },
+      },
+    },
+  };
+}
+
+// ─── TIPO TREND DATA ───
+
+export function getTipoTrendData(
+  typeTemporalData: TypeTemporalDatum[],
+  selectedTipo: string,
+  groupBy: "month" | "year",
+) {
+  const filtered = typeTemporalData.filter(
+    (item) => item.type === selectedTipo,
+  );
+
+  const periods = Array.from(
+    new Set(filtered.map((item) => item.period)),
+  ).sort();
+
+  const gastos = periods.map((period) => {
+    const item = filtered.find(
+      (d) => d.period === period && d.action === "Gasto",
+    );
+    return item ? Math.abs(Number(item.total)) : 0;
+  });
+
+  const ingresos = periods.map((period) => {
+    const item = filtered.find(
+      (d) => d.period === period && d.action === "Ingreso",
+    );
+    return item ? Math.abs(Number(item.total)) : 0;
+  });
+
+  const counts = periods.map((period) => {
+    return filtered
+      .filter((d) => d.period === period)
+      .reduce((sum, d) => sum + (d.count || 0), 0);
+  });
+
+  const n = gastos.length;
+  let trendSlope = 0;
+  if (n > 1) {
+    const sumX = gastos.reduce((sum, _, i) => sum + i, 0);
+    const sumY = gastos.reduce((sum, v) => sum + v, 0);
+    const sumXY = gastos.reduce((sum, v, i) => sum + i * v, 0);
+    const sumXX = gastos.reduce((sum, _, i) => sum + i * i, 0);
+    trendSlope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  }
+
+  const trendLine = gastos.map((_, i) => {
+    const sumY = gastos.reduce((sum, v) => sum + v, 0);
+    const avgY = sumY / n;
+    return avgY + trendSlope * (i - (n - 1) / 2);
+  });
+
+  return {
+    labels: periods.map((p) => {
+      const d = new Date(p as string);
+      return groupBy === "year"
+        ? format(d, "yyyy", { locale: es })
+        : format(d, "MMM yyyy", { locale: es });
+    }),
+    datasets: [
+      {
+        label: "Gasto",
+        data: gastos,
+        borderColor: "rgba(239, 68, 68, 1)",
+        backgroundColor: "rgba(239, 68, 68, 0.1)",
+        fill: true,
+        tension: 0.3,
+      },
+      {
+        label: "Ingreso",
+        data: ingresos,
+        borderColor: "rgba(34, 197, 94, 1)",
+        backgroundColor: "rgba(34, 197, 94, 0.1)",
+        fill: true,
+        tension: 0.3,
+      },
+      {
+        label: "Tendencia",
+        data: trendLine,
+        borderColor: "rgba(168, 85, 247, 1)",
+        backgroundColor: "rgba(168, 85, 247, 0)",
+        borderDash: [6, 3],
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: false,
+      },
+    ],
+    counts,
+    trendSlope,
+  };
+}
+
+// ─── TIPO-LEVEL SPENDING VELOCITY ───
+
+export function computeTipoSpendingVelocity(
+  typeTemporalData: TypeTemporalDatum[],
+  action: string = "Gasto",
+): VelocityItem[] {
+  const filtered = typeTemporalData.filter((item) => item.action === action);
+
+  const byType = new Map<string, Map<string, number>>();
+  for (const item of filtered) {
+    if (!byType.has(item.type)) {
+      byType.set(item.type, new Map());
+    }
+    byType.get(item.type)!.set(item.period, Math.abs(Number(item.total)));
+  }
+
+  const velocities: VelocityItem[] = [];
+  for (const [category, periodMap] of byType) {
+    const periods = Array.from(periodMap.keys()).sort();
+    if (periods.length < 2) continue;
+
+    const current = periodMap.get(periods[periods.length - 1]) || 0;
+    const previous = periodMap.get(periods[periods.length - 2]) || 0;
+
+    const change = current - previous;
+    const changePercent = previous > 0 ? (change / previous) * 100 : 0;
+
+    velocities.push({
+      category,
+      current,
+      previous,
+      change,
+      changePercent,
+      direction: change > 0.01 ? "up" : change < -0.01 ? "down" : "flat",
+    });
+  }
+
+  return velocities.sort((a, b) => Math.abs(b.changePercent) - Math.abs(a.changePercent));
+}
+
+// ─── TIPO-LEVEL SEASONAL PATTERNS ───
+
+export function getTipoSeasonalPatterns(
+  typeTemporalData: TypeTemporalDatum[],
+  selectedTipo: string,
+  action: string = "Gasto",
+): SeasonalItem[] {
+  const filtered = typeTemporalData.filter(
+    (item) => item.type === selectedTipo && item.action === action,
+  );
+
+  const monthNames = [
+    "Ene", "Feb", "Mar", "Abr", "May", "Jun",
+    "Jul", "Ago", "Sep", "Oct", "Nov", "Dic",
+  ];
+
+  const byMonth = new Map<number, { total: number; count: number; yearCount: number }>();
+  for (let i = 0; i < 12; i++) {
+    byMonth.set(i, { total: 0, count: 0, yearCount: 0 });
+  }
+
+  for (const item of filtered) {
+    const d = new Date(item.period);
+    const month = d.getUTCMonth();
+    const existing = byMonth.get(month)!;
+    existing.total += Math.abs(Number(item.total));
+    existing.count += item.count || 0;
+    existing.yearCount += 1;
+  }
+
+  return Array.from(byMonth.entries()).map(([month, data]) => ({
+    month,
+    monthName: monthNames[month],
+    total: data.yearCount > 0 ? data.total / data.yearCount : 0,
+    count: data.yearCount > 0 ? Math.round(data.count / data.yearCount) : 0,
+  }));
 }

--- a/lib/api-keys.ts
+++ b/lib/api-keys.ts
@@ -1,8 +1,9 @@
 import { createClient } from "@vercel/postgres";
-import { randomBytes, createHash } from "crypto";
+import { randomBytes, createHash, createHmac, timingSafeEqual } from "crypto";
 import { v4 as uuidv4 } from "uuid";
 
 const PREFIX = "fa_";
+const KEY_RANDOM_BYTES = 32; // 256 bits of entropy
 
 export interface ApiKey {
   id: string;
@@ -21,27 +22,69 @@ export interface ApiKeyWithPlaintext extends ApiKey {
 
 export type SafeApiKey = Omit<ApiKey, "key_hash">;
 
+let pepperWarningEmitted = false;
+
+/**
+ * Compute the storage hash for an API key.
+ *
+ * SECURITY: API keys used to be stored as plain SHA-256 digests with no
+ * salt or pepper. SHA-256 is fast and unsalted hashes can be brute-forced
+ * if the database is ever leaked. We now hash with HMAC-SHA-256 keyed by
+ * a server-side pepper (`API_KEY_PEPPER`). An attacker who dumps the
+ * database alone cannot mount an offline attack — they also need the
+ * application secret. Legacy plain-SHA-256 hashes are still accepted at
+ * verification time so existing keys keep working through the rollout.
+ */
+export function hashApiKey(key: string): string {
+  const pepper = process.env.API_KEY_PEPPER;
+  if (pepper && pepper.length > 0) {
+    return createHmac("sha256", pepper).update(key).digest("hex");
+  }
+  if (!pepperWarningEmitted) {
+    console.warn(
+      "[api-keys] API_KEY_PEPPER is not set; falling back to plain SHA-256. " +
+        "Set API_KEY_PEPPER to a high-entropy random string to enable HMAC hashing."
+    );
+    pepperWarningEmitted = true;
+  }
+  return createHash("sha256").update(key).digest("hex");
+}
+
+/**
+ * Compute the legacy (plain SHA-256) hash. Used as a fallback so keys
+ * minted before the pepper rollout still verify.
+ */
+function legacyHashApiKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+/**
+ * Hex-string equality in constant time. Prevents trivial timing leaks
+ * even though our verification uses an indexed DB lookup.
+ */
+function safeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Generate a cryptographically secure API key.
- * Format: fa_<32 random hex chars>
- * Returns the plaintext key (shown once to user) and its hash.
+ * Format: fa_<64 random hex chars>
+ * Returns the plaintext key (shown once) and its hash.
  */
 export function generateApiKey(): { plaintext: string; hash: string } {
-  const plaintext = `${PREFIX}${randomBytes(24).toString("hex")}`;
+  const plaintext = `${PREFIX}${randomBytes(KEY_RANDOM_BYTES).toString("hex")}`;
   const hash = hashApiKey(plaintext);
   return { plaintext, hash };
 }
 
-/**
- * Hash an API key using SHA-256.
- */
-export function hashApiKey(key: string): string {
-  return createHash("sha256").update(key).digest("hex");
-}
-
 function stripKeyHash(key: ApiKey): SafeApiKey {
   const safeKey = { ...key };
-  delete safeKey.key_hash;
+  delete (safeKey as Partial<ApiKey>).key_hash;
   return safeKey;
 }
 
@@ -82,30 +125,46 @@ export async function createApiKey(
 export async function verifyApiKey(
   plaintextKey: string
 ): Promise<{ userId: string; keyId: string } | null> {
-  const hash = hashApiKey(plaintextKey);
+  if (!plaintextKey || !plaintextKey.startsWith(PREFIX)) {
+    return null;
+  }
+
+  const candidates = Array.from(
+    new Set([hashApiKey(plaintextKey), legacyHashApiKey(plaintextKey)])
+  );
 
   const client = createClient();
   await client.connect();
 
   try {
-    const result = await client.sql`
-      SELECT id, user_id
-      FROM api_keys
-      WHERE key_hash = ${hash}
-        AND is_active = true
-      LIMIT 1
-    `;
+    // We look up by either of the candidate hashes. ANY ($1) on a text[]
+    // is parameterized, so this stays injection-safe.
+    const result = await client.query(
+      `SELECT id, user_id, key_hash
+         FROM api_keys
+        WHERE key_hash = ANY($1::text[])
+          AND is_active = true
+        LIMIT 1`,
+      [candidates]
+    );
 
     if (result.rows.length === 0) {
       return null;
     }
 
-    const row = result.rows[0];
+    const row = result.rows[0] as ApiKey;
+
+    // Final safety net: confirm the stored hash actually matches one of
+    // our candidates with a timing-safe comparison.
+    const matches = candidates.some((c) => safeHexEqual(c, row.key_hash));
+    if (!matches) {
+      return null;
+    }
 
     await client.sql`
       UPDATE api_keys
-      SET last_used_at = NOW()
-      WHERE id = ${row.id}
+         SET last_used_at = NOW()
+       WHERE id = ${row.id}
     `;
 
     return {
@@ -120,16 +179,18 @@ export async function verifyApiKey(
 /**
  * List all API keys for a user (without hashes).
  */
-export async function listApiKeys(userId: string): Promise<Omit<ApiKey, "key_hash">[]> {
+export async function listApiKeys(
+  userId: string
+): Promise<Omit<ApiKey, "key_hash">[]> {
   const client = createClient();
   await client.connect();
 
   try {
     const result = await client.sql`
       SELECT id, user_id, name, is_active, created_at, updated_at, last_used_at
-      FROM api_keys
-      WHERE user_id = ${userId}
-      ORDER BY created_at DESC
+        FROM api_keys
+       WHERE user_id = ${userId}
+       ORDER BY created_at DESC
     `;
 
     return (result.rows as ApiKey[]).map(stripKeyHash);
@@ -148,9 +209,9 @@ export async function getApiKeyById(
   try {
     const result = await client.sql`
       SELECT id, user_id, key_hash, name, is_active, created_at, updated_at, last_used_at
-      FROM api_keys
-      WHERE id = ${keyId} AND user_id = ${userId}
-      LIMIT 1
+        FROM api_keys
+       WHERE id = ${keyId} AND user_id = ${userId}
+       LIMIT 1
     `;
 
     if (result.rows.length === 0) {
@@ -176,11 +237,11 @@ export async function revokeApiKey(
   try {
     const result = await client.sql`
       UPDATE api_keys
-      SET is_active = false, updated_at = NOW()
-      WHERE id = ${keyId} AND user_id = ${userId}
+         SET is_active = false, updated_at = NOW()
+       WHERE id = ${keyId} AND user_id = ${userId}
     `;
 
-    return result.rowCount > 0;
+    return (result.rowCount ?? 0) > 0;
   } finally {
     await client.end();
   }
@@ -199,10 +260,10 @@ export async function deleteApiKey(
   try {
     const result = await client.sql`
       DELETE FROM api_keys
-      WHERE id = ${keyId} AND user_id = ${userId}
+       WHERE id = ${keyId} AND user_id = ${userId}
     `;
 
-    return result.rowCount > 0;
+    return (result.rowCount ?? 0) > 0;
   } finally {
     await client.end();
   }

--- a/lib/auth/server.ts
+++ b/lib/auth/server.ts
@@ -1,0 +1,54 @@
+import { getServerSession, type Session } from "next-auth";
+import { NextResponse } from "next/server";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+export interface AuthorizedSession {
+  session: Session;
+  userId: string;
+}
+
+/**
+ * Helper for route handlers and server actions: returns the active
+ * session (and a typed userId), or throws an Error with a known shape
+ * that callers can convert to a 401 response.
+ *
+ * Most route handlers want the response variant — see `requireSessionOrUnauthorized`.
+ */
+export async function requireSession(): Promise<AuthorizedSession> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    throw new UnauthorizedError();
+  }
+  return { session, userId: session.user.id };
+}
+
+export class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+/**
+ * For Route Handlers: returns either an `AuthorizedSession` or a
+ * pre-built 401 `NextResponse`. The result is a tagged union so
+ * callers can branch with a single `if`.
+ *
+ *   const auth = await requireSessionOrUnauthorized();
+ *   if ("response" in auth) return auth.response;
+ *   const { userId } = auth;
+ */
+export async function requireSessionOrUnauthorized(): Promise<
+  AuthorizedSession | { response: NextResponse }
+> {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return {
+      response: NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      ),
+    };
+  }
+  return { session, userId: session.user.id };
+}

--- a/lib/crypto/holdings.ts
+++ b/lib/crypto/holdings.ts
@@ -1,0 +1,105 @@
+import type { CryptoHoldingsSummary } from "@/types/finance";
+import { withClient } from "@/lib/db";
+
+/**
+ * Aggregate holdings across all of a user's crypto transactions and
+ * derive a per-symbol balance + cost basis. The CTE structure is
+ * preserved verbatim from the original implementation in
+ * `lib/cryptoActions.ts`; only the connection management was lifted
+ * into the shared `withClient` helper.
+ */
+export async function aggregateHoldings(
+  userId: string
+): Promise<CryptoHoldingsSummary[]> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      WITH crypto_movements AS (
+        SELECT
+          crypto_symbol,
+          SUM(CASE
+            WHEN transaction_type IN ('deposit', 'staking', 'airdrop') THEN amount
+            ELSE 0
+          END) AS deposited,
+          SUM(CASE
+            WHEN transaction_type = 'deposit' THEN amount * COALESCE(price_at_transaction, 0)
+            ELSE 0
+          END) AS invested,
+          SUM(CASE
+            WHEN transaction_type = 'withdrawal' THEN amount
+            ELSE 0
+          END) AS withdrawn,
+          SUM(CASE
+            WHEN transaction_type = 'exchange' THEN amount
+            ELSE 0
+          END) AS exchanged_out,
+          SUM(CASE
+            WHEN fee_crypto = crypto_symbol THEN fee
+            ELSE 0
+          END) AS fees_paid
+        FROM crypto_transactions
+        WHERE user_id = ${userId}
+        GROUP BY crypto_symbol
+      ),
+      exchanges_in AS (
+        SELECT
+          to_crypto_symbol AS crypto_symbol,
+          SUM(to_amount) AS exchanged_in
+        FROM crypto_transactions
+        WHERE user_id = ${userId}
+          AND transaction_type = 'exchange'
+          AND to_crypto_symbol IS NOT NULL
+        GROUP BY to_crypto_symbol
+      )
+      SELECT
+        m.crypto_symbol,
+        (
+          COALESCE(m.deposited, 0)
+          - COALESCE(m.withdrawn, 0)
+          - COALESCE(m.exchanged_out, 0)
+          + COALESCE(e.exchanged_in, 0)
+          - COALESCE(m.fees_paid, 0)
+        ) AS total_amount,
+        m.invested AS total_invested
+      FROM crypto_movements m
+      LEFT JOIN exchanges_in e ON m.crypto_symbol = e.crypto_symbol
+      WHERE (
+        COALESCE(m.deposited, 0)
+        - COALESCE(m.withdrawn, 0)
+        - COALESCE(m.exchanged_out, 0)
+        + COALESCE(e.exchanged_in, 0)
+        - COALESCE(m.fees_paid, 0)
+      ) > 0
+      ORDER BY m.invested DESC NULLS LAST
+    `;
+
+    return result.rows.map((row) => {
+      const totalAmount = parseFloat(row.total_amount as string);
+      const totalInvested = parseFloat((row.total_invested as string) || "0");
+      return {
+        symbol: row.crypto_symbol as string,
+        totalAmount,
+        totalInvested,
+        averagePrice:
+          totalAmount > 0 ? totalInvested / totalAmount : 0,
+      };
+    });
+  });
+}
+
+/**
+ * Distinct crypto symbols a user has interacted with — both source and
+ * destination of exchanges count.
+ */
+export async function listUserSymbols(userId: string): Promise<string[]> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      SELECT DISTINCT crypto_symbol FROM crypto_transactions
+       WHERE user_id = ${userId}
+      UNION
+      SELECT DISTINCT to_crypto_symbol FROM crypto_transactions
+       WHERE user_id = ${userId} AND to_crypto_symbol IS NOT NULL
+      ORDER BY 1
+    `;
+    return result.rows.map((row) => row.crypto_symbol as string);
+  });
+}

--- a/lib/crypto/mappers.ts
+++ b/lib/crypto/mappers.ts
@@ -1,0 +1,51 @@
+import type { CryptoTransaction, CryptoWallet } from "@/types/finance";
+
+/**
+ * Convert a snake_case row from `crypto_transactions` into the
+ * camelCase domain object the rest of the app uses.
+ *
+ * Pulled out of `lib/cryptoActions.ts` so transactions, holdings,
+ * wallets, and tests can share one source of truth instead of
+ * duplicating mapping logic.
+ */
+export function mapDbRowToTransaction(
+  row: Record<string, unknown>
+): CryptoTransaction {
+  return {
+    id: row.id as string,
+    recordId: row.record_id as string | null,
+    transactionType:
+      row.transaction_type as CryptoTransaction["transactionType"],
+    cryptoSymbol: row.crypto_symbol as string,
+    amount: parseFloat(row.amount as string),
+    priceAtTransaction: row.price_at_transaction
+      ? parseFloat(row.price_at_transaction as string)
+      : null,
+    toCryptoSymbol: row.to_crypto_symbol as string | null,
+    toAmount: row.to_amount ? parseFloat(row.to_amount as string) : null,
+    fromWallet: row.from_wallet as string | null,
+    toWallet: row.to_wallet as string | null,
+    fee: parseFloat((row.fee as string) || "0"),
+    feeCrypto: row.fee_crypto as string | null,
+    notes: row.notes as string | null,
+    transactionDate: (row.transaction_date as Date).toISOString(),
+    externalTxId: row.external_tx_id as string | null,
+    userId: row.user_id as string,
+    createdAt: (row.created_at as Date).toISOString(),
+    updatedAt: (row.updated_at as Date).toISOString(),
+  };
+}
+
+export function mapDbRowToWallet(row: Record<string, unknown>): CryptoWallet {
+  return {
+    id: row.id as string,
+    userId: row.user_id as string,
+    name: row.name as string,
+    walletType: row.wallet_type as CryptoWallet["walletType"],
+    address: row.address as string | null,
+    notes: row.notes as string | null,
+    active: row.active as boolean,
+    createdAt: (row.created_at as Date).toISOString(),
+    updatedAt: (row.updated_at as Date).toISOString(),
+  };
+}

--- a/lib/crypto/transactions.ts
+++ b/lib/crypto/transactions.ts
@@ -1,0 +1,310 @@
+import { v4 as uuidv4 } from "uuid";
+import type {
+  CryptoTransaction,
+  CryptoTransactionFormData,
+} from "@/types/finance";
+import { withClient } from "@/lib/db";
+import { escapeLikePattern } from "@/lib/utils";
+import { mapDbRowToTransaction } from "./mappers";
+
+/**
+ * Crypto transaction queries and mutations.
+ *
+ * Extracted from the 592-line `lib/cryptoActions.ts` so each domain
+ * (transactions / wallets / holdings) lives in its own module. The
+ * `lib/cryptoActions.ts` "use server" facade re-exports these.
+ */
+
+export interface CryptoTransactionFilter {
+  search?: string;
+  transactionType?: string;
+  cryptoSymbol?: string;
+  wallet?: string;
+  from?: string;
+  to?: string;
+  page: number;
+  itemsPerPage: number;
+  sortBy?: string;
+  sortOrder?: string;
+}
+
+export interface PaginatedCryptoTransactions {
+  transactions: CryptoTransaction[];
+  total: number;
+  totalPages: number;
+}
+
+const VALID_SORT_FIELDS = new Set([
+  "transaction_date",
+  "crypto_symbol",
+  "amount",
+  "transaction_type",
+  "created_at",
+]);
+
+interface CompiledFilter {
+  whereClause: string;
+  params: (string | number)[];
+  nextParamIndex: number;
+}
+
+function compileTransactionFilter(
+  filters: Omit<
+    CryptoTransactionFilter,
+    "page" | "itemsPerPage" | "sortBy" | "sortOrder"
+  >,
+  userId: string
+): CompiledFilter {
+  const conditions: string[] = ["user_id = $1"];
+  const params: (string | number)[] = [userId];
+  let paramIndex = 2;
+
+  if (filters.search) {
+    conditions.push(`(
+      crypto_symbol ILIKE $${paramIndex} OR
+      to_crypto_symbol ILIKE $${paramIndex} OR
+      from_wallet ILIKE $${paramIndex} OR
+      to_wallet ILIKE $${paramIndex} OR
+      notes ILIKE $${paramIndex}
+    )`);
+    params.push(`%${escapeLikePattern(filters.search)}%`);
+    paramIndex++;
+  }
+
+  if (filters.transactionType && filters.transactionType !== "all") {
+    conditions.push(`transaction_type = $${paramIndex}`);
+    params.push(filters.transactionType);
+    paramIndex++;
+  }
+
+  if (filters.cryptoSymbol) {
+    conditions.push(
+      `(crypto_symbol = $${paramIndex} OR to_crypto_symbol = $${paramIndex})`
+    );
+    params.push(filters.cryptoSymbol);
+    paramIndex++;
+  }
+
+  if (filters.wallet) {
+    conditions.push(
+      `(from_wallet = $${paramIndex} OR to_wallet = $${paramIndex})`
+    );
+    params.push(filters.wallet);
+    paramIndex++;
+  }
+
+  if (filters.from) {
+    conditions.push(`transaction_date >= $${paramIndex}`);
+    params.push(filters.from);
+    paramIndex++;
+  }
+
+  if (filters.to) {
+    conditions.push(`transaction_date <= $${paramIndex}`);
+    params.push(filters.to);
+    paramIndex++;
+  }
+
+  return {
+    whereClause: conditions.join(" AND "),
+    params,
+    nextParamIndex: paramIndex,
+  };
+}
+
+export async function listTransactions(
+  filters: CryptoTransactionFilter,
+  userId: string
+): Promise<PaginatedCryptoTransactions> {
+  const {
+    page = 1,
+    itemsPerPage = 50,
+    sortBy = "transaction_date",
+    sortOrder = "desc",
+    ...rest
+  } = filters;
+  const { whereClause, params, nextParamIndex } = compileTransactionFilter(
+    rest,
+    userId
+  );
+
+  const safeSortBy = VALID_SORT_FIELDS.has(sortBy) ? sortBy : "transaction_date";
+  const safeSortOrder = sortOrder === "asc" ? "ASC" : "DESC";
+
+  return withClient(async (client) => {
+    const countResult = await client.query(
+      `SELECT COUNT(*) FROM crypto_transactions WHERE ${whereClause}`,
+      params
+    );
+    const total = parseInt(countResult.rows[0].count, 10);
+
+    const offset = (page - 1) * itemsPerPage;
+    const dataResult = await client.query(
+      `SELECT * FROM crypto_transactions
+        WHERE ${whereClause}
+        ORDER BY ${safeSortBy} ${safeSortOrder}
+        LIMIT $${nextParamIndex} OFFSET $${nextParamIndex + 1}`,
+      [...params, itemsPerPage, offset]
+    );
+
+    return {
+      transactions: dataResult.rows.map(mapDbRowToTransaction),
+      total,
+      totalPages: Math.ceil(total / itemsPerPage),
+    };
+  });
+}
+
+export async function findTransactionById(
+  id: string,
+  userId: string
+): Promise<CryptoTransaction | null> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      SELECT * FROM crypto_transactions
+       WHERE id = ${id} AND user_id = ${userId}
+       LIMIT 1
+    `;
+    if (result.rows.length === 0) return null;
+    return mapDbRowToTransaction(result.rows[0]);
+  });
+}
+
+export async function insertTransaction(
+  formData: CryptoTransactionFormData,
+  userId: string
+): Promise<CryptoTransaction> {
+  const id = uuidv4();
+  const now = new Date();
+
+  return withClient(async (client) => {
+    const result = await client.sql`
+      INSERT INTO crypto_transactions (
+        id, record_id, transaction_type, crypto_symbol, amount,
+        price_at_transaction, to_crypto_symbol, to_amount,
+        from_wallet, to_wallet, fee, fee_crypto, notes,
+        transaction_date, external_tx_id, user_id, created_at, updated_at
+      ) VALUES (
+        ${id},
+        ${formData.recordId || null},
+        ${formData.transactionType},
+        ${formData.cryptoSymbol.toUpperCase()},
+        ${formData.amount},
+        ${formData.priceAtTransaction || null},
+        ${formData.toCryptoSymbol?.toUpperCase() || null},
+        ${formData.toAmount || null},
+        ${formData.fromWallet || null},
+        ${formData.toWallet || null},
+        ${formData.fee || 0},
+        ${formData.feeCrypto?.toUpperCase() || null},
+        ${formData.notes || null},
+        ${formData.transactionDate},
+        ${formData.externalTxId || null},
+        ${userId},
+        ${now.toISOString()},
+        ${now.toISOString()}
+      )
+      RETURNING *
+    `;
+    return mapDbRowToTransaction(result.rows[0]);
+  });
+}
+
+export async function updateTransactionById(
+  id: string,
+  formData: Partial<CryptoTransactionFormData>,
+  userId: string
+): Promise<CryptoTransaction | null> {
+  return withClient(async (client) => {
+    const existing = await client.sql`
+      SELECT id FROM crypto_transactions
+       WHERE id = ${id} AND user_id = ${userId}
+       LIMIT 1
+    `;
+    if (existing.rows.length === 0) return null;
+
+    const now = new Date();
+    const result = await client.sql`
+      UPDATE crypto_transactions SET
+        transaction_type     = COALESCE(${formData.transactionType}, transaction_type),
+        crypto_symbol        = COALESCE(${formData.cryptoSymbol?.toUpperCase()}, crypto_symbol),
+        amount               = COALESCE(${formData.amount}, amount),
+        price_at_transaction = COALESCE(${formData.priceAtTransaction}, price_at_transaction),
+        to_crypto_symbol     = COALESCE(${formData.toCryptoSymbol?.toUpperCase()}, to_crypto_symbol),
+        to_amount            = COALESCE(${formData.toAmount}, to_amount),
+        from_wallet          = COALESCE(${formData.fromWallet}, from_wallet),
+        to_wallet            = COALESCE(${formData.toWallet}, to_wallet),
+        fee                  = COALESCE(${formData.fee}, fee),
+        fee_crypto           = COALESCE(${formData.feeCrypto?.toUpperCase()}, fee_crypto),
+        notes                = COALESCE(${formData.notes}, notes),
+        transaction_date     = COALESCE(${formData.transactionDate}, transaction_date),
+        external_tx_id       = COALESCE(${formData.externalTxId}, external_tx_id),
+        updated_at           = ${now.toISOString()}
+      WHERE id = ${id} AND user_id = ${userId}
+      RETURNING *
+    `;
+    return mapDbRowToTransaction(result.rows[0]);
+  });
+}
+
+export async function deleteTransactionById(
+  id: string,
+  userId: string
+): Promise<boolean> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      DELETE FROM crypto_transactions
+       WHERE id = ${id} AND user_id = ${userId}
+       RETURNING id
+    `;
+    return result.rows.length > 0;
+  });
+}
+
+export async function duplicateTransactionById(
+  id: string,
+  userId: string
+): Promise<CryptoTransaction | null> {
+  return withClient(async (client) => {
+    const existing = await client.sql`
+      SELECT * FROM crypto_transactions
+       WHERE id = ${id} AND user_id = ${userId}
+       LIMIT 1
+    `;
+    if (existing.rows.length === 0) return null;
+
+    const transaction = existing.rows[0];
+    const newId = uuidv4();
+    const now = new Date();
+
+    const result = await client.sql`
+      INSERT INTO crypto_transactions (
+        id, record_id, transaction_type, crypto_symbol, amount,
+        price_at_transaction, to_crypto_symbol, to_amount,
+        from_wallet, to_wallet, fee, fee_crypto, notes,
+        transaction_date, external_tx_id, user_id, created_at, updated_at
+      ) VALUES (
+        ${newId},
+        ${transaction.record_id},
+        ${transaction.transaction_type},
+        ${transaction.crypto_symbol},
+        ${transaction.amount},
+        ${transaction.price_at_transaction},
+        ${transaction.to_crypto_symbol},
+        ${transaction.to_amount},
+        ${transaction.from_wallet},
+        ${transaction.to_wallet},
+        ${transaction.fee},
+        ${transaction.fee_crypto},
+        ${transaction.notes},
+        ${transaction.transaction_date},
+        ${transaction.external_tx_id},
+        ${userId},
+        ${now.toISOString()},
+        ${now.toISOString()}
+      )
+      RETURNING *
+    `;
+    return mapDbRowToTransaction(result.rows[0]);
+  });
+}

--- a/lib/crypto/wallets.ts
+++ b/lib/crypto/wallets.ts
@@ -1,0 +1,64 @@
+import { v4 as uuidv4 } from "uuid";
+import type { CryptoWallet } from "@/types/finance";
+import { withClient } from "@/lib/db";
+import { mapDbRowToWallet } from "./mappers";
+
+export async function listWallets(userId: string): Promise<CryptoWallet[]> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      SELECT * FROM crypto_wallets
+       WHERE user_id = ${userId} AND active = true
+       ORDER BY name ASC
+    `;
+    return result.rows.map(mapDbRowToWallet);
+  });
+}
+
+export async function insertWallet(
+  data: { name: string; walletType: string; address?: string; notes?: string },
+  userId: string
+): Promise<CryptoWallet> {
+  const id = uuidv4();
+  const now = new Date();
+
+  return withClient(async (client) => {
+    const result = await client.sql`
+      INSERT INTO crypto_wallets (
+        id, user_id, name, wallet_type, address, notes,
+        active, created_at, updated_at
+      ) VALUES (
+        ${id},
+        ${userId},
+        ${data.name},
+        ${data.walletType},
+        ${data.address || null},
+        ${data.notes || null},
+        true,
+        ${now.toISOString()},
+        ${now.toISOString()}
+      )
+      RETURNING *
+    `;
+    return mapDbRowToWallet(result.rows[0]);
+  });
+}
+
+/**
+ * Distinct wallet names that have actually been used as a from_wallet
+ * or to_wallet in any of the user's transactions. Useful for autocomplete.
+ */
+export async function listUsedWallets(userId: string): Promise<string[]> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      SELECT DISTINCT wallet FROM (
+        SELECT from_wallet AS wallet FROM crypto_transactions
+         WHERE user_id = ${userId} AND from_wallet IS NOT NULL
+        UNION
+        SELECT to_wallet AS wallet FROM crypto_transactions
+         WHERE user_id = ${userId} AND to_wallet IS NOT NULL
+      ) AS wallets
+      ORDER BY wallet
+    `;
+    return result.rows.map((row) => row.wallet as string);
+  });
+}

--- a/lib/cryptoActions.ts
+++ b/lib/cryptoActions.ts
@@ -1,264 +1,81 @@
 "use server";
 
-import { createClient } from "@vercel/postgres";
+/**
+ * Server-action facade for the crypto domain.
+ *
+ * The previous version of this file was 592 lines that mixed
+ * transaction CRUD, wallet CRUD, holdings aggregation, mapping
+ * helpers, and connection management. The implementation now lives in
+ * focused modules:
+ *   - lib/crypto/transactions.ts
+ *   - lib/crypto/wallets.ts
+ *   - lib/crypto/holdings.ts
+ *   - lib/crypto/mappers.ts
+ *
+ * This file is the small "use server" boundary that client components
+ * (crypto-transaction-form, crypto-transaction-table) and API routes
+ * import from. The signatures are preserved 1:1 so existing callers
+ * keep working.
+ */
+
 import { revalidatePath } from "next/cache";
-import { v4 as uuidv4 } from "uuid";
 import type {
+  CryptoHoldingsSummary,
   CryptoTransaction,
   CryptoTransactionFormData,
   CryptoWallet,
-  CryptoHoldingsSummary,
 } from "@/types/finance";
+import {
+  type CryptoTransactionFilter,
+  type PaginatedCryptoTransactions,
+  deleteTransactionById,
+  duplicateTransactionById,
+  findTransactionById,
+  insertTransaction,
+  listTransactions,
+  updateTransactionById,
+} from "@/lib/crypto/transactions";
+import {
+  insertWallet,
+  listUsedWallets,
+  listWallets,
+} from "@/lib/crypto/wallets";
+import {
+  aggregateHoldings,
+  listUserSymbols,
+} from "@/lib/crypto/holdings";
 
-interface CryptoTransactionFilter {
-  search?: string;
-  transactionType?: string;
-  cryptoSymbol?: string;
-  wallet?: string;
-  from?: string;
-  to?: string;
-  page: number;
-  itemsPerPage: number;
-  sortBy?: string;
-  sortOrder?: string;
-}
+// Re-export the filter type so existing API routes can keep importing
+// it from "@/lib/cryptoActions".
+export type { CryptoTransactionFilter, PaginatedCryptoTransactions };
 
-interface PaginatedCryptoTransactions {
-  transactions: CryptoTransaction[];
-  total: number;
-  totalPages: number;
-}
-
-// Helper function to convert snake_case DB row to camelCase
-function mapDbRowToTransaction(
-  row: Record<string, unknown>
-): CryptoTransaction {
-  return {
-    id: row.id as string,
-    recordId: row.record_id as string | null,
-    transactionType:
-      row.transaction_type as CryptoTransaction["transactionType"],
-    cryptoSymbol: row.crypto_symbol as string,
-    amount: parseFloat(row.amount as string),
-    priceAtTransaction: row.price_at_transaction
-      ? parseFloat(row.price_at_transaction as string)
-      : null,
-    toCryptoSymbol: row.to_crypto_symbol as string | null,
-    toAmount: row.to_amount ? parseFloat(row.to_amount as string) : null,
-    fromWallet: row.from_wallet as string | null,
-    toWallet: row.to_wallet as string | null,
-    fee: parseFloat((row.fee as string) || "0"),
-    feeCrypto: row.fee_crypto as string | null,
-    notes: row.notes as string | null,
-    transactionDate: (row.transaction_date as Date).toISOString(),
-    externalTxId: row.external_tx_id as string | null,
-    userId: row.user_id as string,
-    createdAt: (row.created_at as Date).toISOString(),
-    updatedAt: (row.updated_at as Date).toISOString(),
-  };
-}
-
-function mapDbRowToWallet(row: Record<string, unknown>): CryptoWallet {
-  return {
-    id: row.id as string,
-    userId: row.user_id as string,
-    name: row.name as string,
-    walletType: row.wallet_type as CryptoWallet["walletType"],
-    address: row.address as string | null,
-    notes: row.notes as string | null,
-    active: row.active as boolean,
-    createdAt: (row.created_at as Date).toISOString(),
-    updatedAt: (row.updated_at as Date).toISOString(),
-  };
-}
+const CRYPTO_REVALIDATE_PATH = "/investment/crypto";
 
 // ============================================
-// CRYPTO TRANSACTIONS CRUD
+// CRYPTO TRANSACTIONS
 // ============================================
 
 export async function getCryptoTransactions(
   filters: CryptoTransactionFilter,
   session: { user: { id: string } }
 ): Promise<PaginatedCryptoTransactions> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const {
-      search = "",
-      transactionType = "",
-      cryptoSymbol = "",
-      wallet = "",
-      from = "",
-      to = "",
-      page = 1,
-      itemsPerPage = 50,
-      sortBy = "transaction_date",
-      sortOrder = "desc",
-    } = filters;
-
-    // Build WHERE conditions
-    const conditions: string[] = ["user_id = $1"];
-    const params: (string | number)[] = [session.user.id];
-    let paramIndex = 2;
-
-    if (search) {
-      conditions.push(`(
-        crypto_symbol ILIKE $${paramIndex} OR 
-        to_crypto_symbol ILIKE $${paramIndex} OR 
-        from_wallet ILIKE $${paramIndex} OR 
-        to_wallet ILIKE $${paramIndex} OR 
-        notes ILIKE $${paramIndex}
-      )`);
-      params.push(`%${search}%`);
-      paramIndex++;
-    }
-
-    if (transactionType && transactionType !== "all") {
-      conditions.push(`transaction_type = $${paramIndex}`);
-      params.push(transactionType);
-      paramIndex++;
-    }
-
-    if (cryptoSymbol) {
-      conditions.push(
-        `(crypto_symbol = $${paramIndex} OR to_crypto_symbol = $${paramIndex})`
-      );
-      params.push(cryptoSymbol);
-      paramIndex++;
-    }
-
-    if (wallet) {
-      conditions.push(
-        `(from_wallet = $${paramIndex} OR to_wallet = $${paramIndex})`
-      );
-      params.push(wallet);
-      paramIndex++;
-    }
-
-    if (from) {
-      conditions.push(`transaction_date >= $${paramIndex}`);
-      params.push(from);
-      paramIndex++;
-    }
-
-    if (to) {
-      conditions.push(`transaction_date <= $${paramIndex}`);
-      params.push(to);
-      paramIndex++;
-    }
-
-    const whereClause = conditions.join(" AND ");
-
-    // Validate sortBy to prevent SQL injection
-    const validSortFields = [
-      "transaction_date",
-      "crypto_symbol",
-      "amount",
-      "transaction_type",
-      "created_at",
-    ];
-    const safeSortBy = validSortFields.includes(sortBy)
-      ? sortBy
-      : "transaction_date";
-    const safeSortOrder = sortOrder === "asc" ? "ASC" : "DESC";
-
-    // Count total
-    const countQuery = `SELECT COUNT(*) FROM crypto_transactions WHERE ${whereClause}`;
-    const countResult = await client.query(countQuery, params);
-    const total = parseInt(countResult.rows[0].count, 10);
-
-    // Get paginated results
-    const offset = (page - 1) * itemsPerPage;
-    const dataQuery = `
-      SELECT * FROM crypto_transactions 
-      WHERE ${whereClause}
-      ORDER BY ${safeSortBy} ${safeSortOrder}
-      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
-    `;
-    params.push(itemsPerPage, offset);
-
-    const dataResult = await client.query(dataQuery, params);
-    const transactions = dataResult.rows.map(mapDbRowToTransaction);
-
-    return {
-      transactions,
-      total,
-      totalPages: Math.ceil(total / itemsPerPage),
-    };
-  } finally {
-    await client.end();
-  }
+  return listTransactions(filters, session.user.id);
 }
 
 export async function getCryptoTransactionById(
   id: string,
   session: { user: { id: string } }
 ): Promise<CryptoTransaction | null> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const result = await client.sql`
-      SELECT * FROM crypto_transactions 
-      WHERE id = ${id} AND user_id = ${session.user.id}
-    `;
-
-    if (result.rows.length === 0) {
-      return null;
-    }
-
-    return mapDbRowToTransaction(result.rows[0]);
-  } finally {
-    await client.end();
-  }
+  return findTransactionById(id, session.user.id);
 }
 
 export async function createCryptoTransaction(
   formData: CryptoTransactionFormData,
   session: { user: { id: string } }
 ): Promise<CryptoTransaction> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const id = uuidv4();
-    const now = new Date();
-
-    const result = await client.sql`
-      INSERT INTO crypto_transactions (
-        id, record_id, transaction_type, crypto_symbol, amount, 
-        price_at_transaction, to_crypto_symbol, to_amount,
-        from_wallet, to_wallet, fee, fee_crypto, notes,
-        transaction_date, external_tx_id, user_id, created_at, updated_at
-      ) VALUES (
-        ${id},
-        ${formData.recordId || null},
-        ${formData.transactionType},
-        ${formData.cryptoSymbol.toUpperCase()},
-        ${formData.amount},
-        ${formData.priceAtTransaction || null},
-        ${formData.toCryptoSymbol?.toUpperCase() || null},
-        ${formData.toAmount || null},
-        ${formData.fromWallet || null},
-        ${formData.toWallet || null},
-        ${formData.fee || 0},
-        ${formData.feeCrypto?.toUpperCase() || null},
-        ${formData.notes || null},
-        ${formData.transactionDate},
-        ${formData.externalTxId || null},
-        ${session.user.id},
-        ${now.toISOString()},
-        ${now.toISOString()}
-      )
-      RETURNING *
-    `;
-
-    revalidatePath("/investment/crypto");
-    return mapDbRowToTransaction(result.rows[0]);
-  } finally {
-    await client.end();
-  }
+  const result = await insertTransaction(formData, session.user.id);
+  revalidatePath(CRYPTO_REVALIDATE_PATH);
+  return result;
 }
 
 export async function updateCryptoTransaction(
@@ -266,327 +83,66 @@ export async function updateCryptoTransaction(
   formData: Partial<CryptoTransactionFormData>,
   session: { user: { id: string } }
 ): Promise<CryptoTransaction | null> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    // First check if the transaction exists and belongs to the user
-    const existing = await client.sql`
-      SELECT id FROM crypto_transactions 
-      WHERE id = ${id} AND user_id = ${session.user.id}
-    `;
-
-    if (existing.rows.length === 0) {
-      return null;
-    }
-
-    const now = new Date();
-
-    const result = await client.sql`
-      UPDATE crypto_transactions SET
-        transaction_type = COALESCE(${
-          formData.transactionType
-        }, transaction_type),
-        crypto_symbol = COALESCE(${formData.cryptoSymbol?.toUpperCase()}, crypto_symbol),
-        amount = COALESCE(${formData.amount}, amount),
-        price_at_transaction = COALESCE(${
-          formData.priceAtTransaction
-        }, price_at_transaction),
-        to_crypto_symbol = COALESCE(${formData.toCryptoSymbol?.toUpperCase()}, to_crypto_symbol),
-        to_amount = COALESCE(${formData.toAmount}, to_amount),
-        from_wallet = COALESCE(${formData.fromWallet}, from_wallet),
-        to_wallet = COALESCE(${formData.toWallet}, to_wallet),
-        fee = COALESCE(${formData.fee}, fee),
-        fee_crypto = COALESCE(${formData.feeCrypto?.toUpperCase()}, fee_crypto),
-        notes = COALESCE(${formData.notes}, notes),
-        transaction_date = COALESCE(${
-          formData.transactionDate
-        }, transaction_date),
-        external_tx_id = COALESCE(${formData.externalTxId}, external_tx_id),
-        updated_at = ${now.toISOString()}
-      WHERE id = ${id} AND user_id = ${session.user.id}
-      RETURNING *
-    `;
-
-    revalidatePath("/investment/crypto");
-    return mapDbRowToTransaction(result.rows[0]);
-  } finally {
-    await client.end();
-  }
+  const result = await updateTransactionById(id, formData, session.user.id);
+  revalidatePath(CRYPTO_REVALIDATE_PATH);
+  return result;
 }
 
 export async function deleteCryptoTransaction(
   id: string,
   session: { user: { id: string } }
 ): Promise<boolean> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const result = await client.sql`
-      DELETE FROM crypto_transactions 
-      WHERE id = ${id} AND user_id = ${session.user.id}
-      RETURNING id
-    `;
-
-    revalidatePath("/investment/crypto");
-    return result.rows.length > 0;
-  } finally {
-    await client.end();
-  }
+  const ok = await deleteTransactionById(id, session.user.id);
+  revalidatePath(CRYPTO_REVALIDATE_PATH);
+  return ok;
 }
 
 export async function duplicateCryptoTransaction(
   id: string,
   session: { user: { id: string } }
 ): Promise<CryptoTransaction | null> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    // Fetch the existing transaction
-    const existing = await client.sql`
-      SELECT * FROM crypto_transactions 
-      WHERE id = ${id} AND user_id = ${session.user.id}
-    `;
-
-    if (existing.rows.length === 0) {
-      return null;
-    }
-
-    const transaction = existing.rows[0];
-    const newId = uuidv4();
-    const now = new Date();
-
-    // Insert a duplicate transaction with a new ID and timestamps
-    const result = await client.sql`
-      INSERT INTO crypto_transactions (
-        id, record_id, transaction_type, crypto_symbol, amount, 
-        price_at_transaction, to_crypto_symbol, to_amount,
-        from_wallet, to_wallet, fee, fee_crypto, notes,
-        transaction_date, external_tx_id, user_id, created_at, updated_at
-      ) VALUES (
-        ${newId},
-        ${transaction.record_id},
-        ${transaction.transaction_type},
-        ${transaction.crypto_symbol},
-        ${transaction.amount},
-        ${transaction.price_at_transaction},
-        ${transaction.to_crypto_symbol},
-        ${transaction.to_amount},
-        ${transaction.from_wallet},
-        ${transaction.to_wallet},
-        ${transaction.fee},
-        ${transaction.fee_crypto},
-        ${transaction.notes},
-        ${transaction.transaction_date},
-        ${transaction.external_tx_id},
-        ${session.user.id},
-        ${now.toISOString()},
-        ${now.toISOString()}
-      )
-      RETURNING *
-    `;
-
-    revalidatePath("/investment/crypto");
-    return mapDbRowToTransaction(result.rows[0]);
-  } finally {
-    await client.end();
-  }
+  const result = await duplicateTransactionById(id, session.user.id);
+  revalidatePath(CRYPTO_REVALIDATE_PATH);
+  return result;
 }
 
 // ============================================
-// CRYPTO WALLETS CRUD
+// CRYPTO WALLETS
 // ============================================
 
 export async function getCryptoWallets(session: {
   user: { id: string };
 }): Promise<CryptoWallet[]> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const result = await client.sql`
-      SELECT * FROM crypto_wallets 
-      WHERE user_id = ${session.user.id} AND active = true
-      ORDER BY name ASC
-    `;
-
-    return result.rows.map(mapDbRowToWallet);
-  } finally {
-    await client.end();
-  }
+  return listWallets(session.user.id);
 }
 
 export async function createCryptoWallet(
   data: { name: string; walletType: string; address?: string; notes?: string },
   session: { user: { id: string } }
 ): Promise<CryptoWallet> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const id = uuidv4();
-    const now = new Date();
-
-    const result = await client.sql`
-      INSERT INTO crypto_wallets (
-        id, user_id, name, wallet_type, address, notes, active, created_at, updated_at
-      ) VALUES (
-        ${id},
-        ${session.user.id},
-        ${data.name},
-        ${data.walletType},
-        ${data.address || null},
-        ${data.notes || null},
-        true,
-        ${now.toISOString()},
-        ${now.toISOString()}
-      )
-      RETURNING *
-    `;
-
-    revalidatePath("/investment/crypto");
-    return mapDbRowToWallet(result.rows[0]);
-  } finally {
-    await client.end();
-  }
+  const result = await insertWallet(data, session.user.id);
+  revalidatePath(CRYPTO_REVALIDATE_PATH);
+  return result;
 }
 
 // ============================================
-// CRYPTO HOLDINGS SUMMARY
+// CRYPTO HOLDINGS / OPTIONS
 // ============================================
 
 export async function getCryptoHoldings(session: {
   user: { id: string };
 }): Promise<CryptoHoldingsSummary[]> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    // Calculate holdings by aggregating all transactions
-    const result = await client.sql`
-      WITH crypto_movements AS (
-        -- Deposits and purchases (positive)
-        SELECT 
-          crypto_symbol,
-          SUM(CASE 
-            WHEN transaction_type IN ('deposit', 'staking', 'airdrop') THEN amount 
-            ELSE 0 
-          END) as deposited,
-          SUM(CASE 
-            WHEN transaction_type = 'deposit' THEN amount * COALESCE(price_at_transaction, 0)
-            ELSE 0
-          END) as invested,
-          -- Withdrawals (negative)
-          SUM(CASE 
-            WHEN transaction_type = 'withdrawal' THEN amount 
-            ELSE 0 
-          END) as withdrawn,
-          -- Exchanges out (negative)
-          SUM(CASE 
-            WHEN transaction_type = 'exchange' THEN amount 
-            ELSE 0 
-          END) as exchanged_out,
-          -- Fees (negative)
-          SUM(CASE 
-            WHEN fee_crypto = crypto_symbol THEN fee 
-            ELSE 0 
-          END) as fees_paid
-        FROM crypto_transactions
-        WHERE user_id = ${session.user.id}
-        GROUP BY crypto_symbol
-      ),
-      exchanges_in AS (
-        -- Exchanges received (positive)
-        SELECT 
-          to_crypto_symbol as crypto_symbol,
-          SUM(to_amount) as exchanged_in
-        FROM crypto_transactions
-        WHERE user_id = ${session.user.id}
-          AND transaction_type = 'exchange'
-          AND to_crypto_symbol IS NOT NULL
-        GROUP BY to_crypto_symbol
-      )
-      SELECT 
-        m.crypto_symbol,
-        (COALESCE(m.deposited, 0) - COALESCE(m.withdrawn, 0) - COALESCE(m.exchanged_out, 0) + COALESCE(e.exchanged_in, 0) - COALESCE(m.fees_paid, 0)) as total_amount,
-        m.invested as total_invested
-      FROM crypto_movements m
-      LEFT JOIN exchanges_in e ON m.crypto_symbol = e.crypto_symbol
-      WHERE (COALESCE(m.deposited, 0) - COALESCE(m.withdrawn, 0) - COALESCE(m.exchanged_out, 0) + COALESCE(e.exchanged_in, 0) - COALESCE(m.fees_paid, 0)) > 0
-      ORDER BY m.invested DESC NULLS LAST
-    `;
-
-    return result.rows.map((row) => ({
-      symbol: row.crypto_symbol as string,
-      totalAmount: parseFloat(row.total_amount as string),
-      totalInvested: parseFloat((row.total_invested as string) || "0"),
-      averagePrice:
-        parseFloat((row.total_invested as string) || "0") /
-          parseFloat(row.total_amount as string) || 0,
-    }));
-  } finally {
-    await client.end();
-  }
+  return aggregateHoldings(session.user.id);
 }
-
-// ============================================
-// HELPER: Get unique crypto symbols used
-// ============================================
 
 export async function getCryptoSymbols(session: {
   user: { id: string };
 }): Promise<string[]> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const result = await client.sql`
-      SELECT DISTINCT crypto_symbol FROM crypto_transactions
-      WHERE user_id = ${session.user.id}
-      UNION
-      SELECT DISTINCT to_crypto_symbol FROM crypto_transactions
-      WHERE user_id = ${session.user.id} AND to_crypto_symbol IS NOT NULL
-      ORDER BY 1
-    `;
-
-    return result.rows.map((row) => row.crypto_symbol as string);
-  } catch (error) {
-    console.error("Error in getCryptoSymbols:", error);
-    throw error;
-  } finally {
-    await client.end();
-  }
+  return listUserSymbols(session.user.id);
 }
-
-// ============================================
-// HELPER: Get unique wallets used
-// ============================================
 
 export async function getUsedWallets(session: {
   user: { id: string };
 }): Promise<string[]> {
-  const client = createClient();
-  await client.connect();
-
-  try {
-    const result = await client.sql`
-      SELECT DISTINCT wallet FROM (
-        SELECT from_wallet as wallet FROM crypto_transactions
-        WHERE user_id = ${session.user.id} AND from_wallet IS NOT NULL
-        UNION
-        SELECT to_wallet as wallet FROM crypto_transactions
-        WHERE user_id = ${session.user.id} AND to_wallet IS NOT NULL
-      ) AS wallets
-      ORDER BY wallet
-    `;
-
-    return result.rows.map((row) => row.wallet as string);
-  } catch (error) {
-    console.error("Error in getUsedWallets:", error);
-    throw error;
-  } finally {
-    await client.end();
-  }
+  return listUsedWallets(session.user.id);
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,51 @@
+import {
+  createClient,
+  createPool,
+  type VercelClient,
+  type VercelPool,
+} from "@vercel/postgres";
+
+/**
+ * Run `fn` with a connected `@vercel/postgres` client and guarantee the
+ * client is closed afterwards. Existing call sites repeated the
+ * `createClient → connect → try / finally → end` pattern dozens of
+ * times; this helper is the canonical replacement.
+ *
+ * Use this for short, transactional sequences (single INSERT / UPDATE /
+ * DELETE, or 2–3 chained statements). For pure SELECT-style reads
+ * prefer `withPool` — pooled connections survive between requests and
+ * avoid the connect/handshake roundtrip.
+ */
+export async function withClient<T>(
+  fn: (client: VercelClient) => Promise<T>
+): Promise<T> {
+  const client = createClient();
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    try {
+      await client.end();
+    } catch (err) {
+      // Surface but don't mask the original error in the caller.
+      console.error("[db] error closing client:", err);
+    }
+  }
+}
+
+/**
+ * Run `fn` with a `@vercel/postgres` pool and tear it down at the end.
+ * Mirrors `withClient` but for read-mostly handlers.
+ */
+export async function withPool<T>(fn: (pool: VercelPool) => Promise<T>): Promise<T> {
+  const pool = createPool();
+  try {
+    return await fn(pool);
+  } finally {
+    try {
+      await pool.end();
+    } catch (err) {
+      console.error("[db] error closing pool:", err);
+    }
+  }
+}

--- a/lib/entries/repo.ts
+++ b/lib/entries/repo.ts
@@ -1,0 +1,300 @@
+import { v4 as uuidv4 } from "uuid";
+import { withClient, withPool } from "@/lib/db";
+import { escapeLikePattern } from "@/lib/utils";
+
+/**
+ * Database access for the `finance_entries` table.
+ *
+ * This module is intentionally *not* marked with the `"use server"`
+ * directive. It is plain async TypeScript that runs only on the server
+ * (it imports `@vercel/postgres`). The server-action surface that
+ * client components call into lives in `lib/actions.ts`, which simply
+ * forwards to the functions exported here.
+ *
+ * Why split? `lib/actions.ts` had grown into a 415-line file mixing
+ * user CRUD, entry CRUD, query building, and pagination together,
+ * making it the single largest lib module in the codebase. The
+ * "use server" directive also prevents extracting helpers (every
+ * export must be async). Pulling the SQL into a normal module makes
+ * it possible to reuse, test, and reason about each operation.
+ */
+
+export interface EntryFilter {
+  search?: string;
+  accion?: string;
+  tipo?: string;
+  from?: string;
+  to?: string;
+  page: number;
+  itemsPerPage: number;
+  sortBy?: string;
+  sortOrder?: string;
+}
+
+export interface Entry {
+  id: string;
+  fecha: string;
+  tipo: string;
+  accion: string;
+  que: string;
+  plataforma_pago: string;
+  cantidad: number;
+  detalle1?: string;
+  detalle2?: string;
+  quien?: string;
+}
+
+export interface PaginatedEntries {
+  entries: Entry[];
+  total: number;
+  totalPages: number;
+}
+
+export interface EntryInput {
+  fecha: string;
+  tipo: string;
+  accion: string;
+  que: string;
+  plataforma_pago: string;
+  cantidad: number;
+  detalle1?: string;
+  detalle2?: string;
+  quien?: string;
+}
+
+const ALLOWED_SORT_FIELDS = new Set([
+  "fecha",
+  "accion",
+  "que",
+  "tipo",
+  "plataforma_pago",
+  "cantidad",
+  "quien",
+]);
+
+function resolveSort(
+  sortBy: string | undefined,
+  sortOrder: string | undefined
+): { sortField: string; sortDirection: "ASC" | "DESC" } {
+  const sortField =
+    sortBy && ALLOWED_SORT_FIELDS.has(String(sortBy)) ? String(sortBy) : "fecha";
+  const sortDirection =
+    String(sortOrder ?? "").toLowerCase() === "asc" ? "ASC" : "DESC";
+  return { sortField, sortDirection };
+}
+
+interface FilterCompilation {
+  whereStatement: string;
+  params: (string | number)[];
+}
+
+/**
+ * Compile a user-controlled filter into a parameterized WHERE clause.
+ * The user_id predicate is appended unconditionally so callers cannot
+ * forget the per-user scope.
+ */
+function compileFilter(
+  filter: Omit<EntryFilter, "page" | "itemsPerPage" | "sortBy" | "sortOrder">,
+  userId: string
+): FilterCompilation {
+  const whereClauses: string[] = [];
+  const params: (string | number)[] = [];
+  let paramIndex = 1;
+
+  if (filter.search) {
+    whereClauses.push(
+      `(
+        accion ILIKE $${paramIndex} OR
+        que ILIKE $${paramIndex} OR
+        tipo ILIKE $${paramIndex} OR
+        plataforma_pago ILIKE $${paramIndex} OR
+        detalle1 ILIKE $${paramIndex} OR
+        detalle2 ILIKE $${paramIndex} OR
+        quien ILIKE $${paramIndex}
+      )`
+    );
+    params.push(`%${escapeLikePattern(filter.search)}%`);
+    paramIndex++;
+  }
+
+  if (filter.accion && filter.accion !== "todos") {
+    whereClauses.push(`accion = $${paramIndex}`);
+    params.push(filter.accion);
+    paramIndex++;
+  }
+
+  if (filter.tipo && filter.tipo !== "todos") {
+    whereClauses.push(`tipo = $${paramIndex}`);
+    params.push(filter.tipo);
+    paramIndex++;
+  }
+
+  if (filter.from) {
+    whereClauses.push(
+      `fecha >= ($${paramIndex} || 'T00:00:00.000')::timestamptz`
+    );
+    params.push(filter.from);
+    paramIndex++;
+  }
+
+  if (filter.to) {
+    whereClauses.push(
+      `fecha <= ($${paramIndex} || 'T23:59:59.999')::timestamptz`
+    );
+    params.push(filter.to);
+    paramIndex++;
+  }
+
+  whereClauses.push(`user_id = $${paramIndex}`);
+  params.push(userId);
+
+  return {
+    whereStatement:
+      whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "",
+    params,
+  };
+}
+
+export async function findEntries(
+  filters: EntryFilter,
+  userId: string
+): Promise<PaginatedEntries> {
+  const { search, accion, tipo, from, to, page, itemsPerPage, sortBy, sortOrder } =
+    filters;
+  const { whereStatement, params } = compileFilter(
+    { search, accion, tipo, from, to },
+    userId
+  );
+  const { sortField, sortDirection } = resolveSort(sortBy, sortOrder);
+  const offset = (page - 1) * itemsPerPage;
+
+  return withPool(async (pool) => {
+    const countResult = await pool.query(
+      `SELECT COUNT(*)::int AS count FROM finance_entries ${whereStatement}`,
+      params
+    );
+    const total: number = countResult.rows[0]?.count ?? 0;
+
+    const entriesResult = await pool.query(
+      `SELECT id, fecha, tipo, accion, que, plataforma_pago, cantidad,
+              detalle1, detalle2, quien, user_id
+         FROM finance_entries
+         ${whereStatement}
+         ORDER BY ${sortField} ${sortDirection}
+         LIMIT $${params.length + 1}
+         OFFSET $${params.length + 2}`,
+      [...params, itemsPerPage, offset]
+    );
+
+    return {
+      entries: entriesResult.rows as Entry[],
+      total,
+      totalPages: Math.ceil((total || 0) / itemsPerPage),
+    };
+  });
+}
+
+export async function exportEntries(
+  filter: { search?: string; tipo?: string; from?: string; to?: string },
+  userId: string
+): Promise<Entry[]> {
+  const { whereStatement, params } = compileFilter(
+    {
+      search: filter.search ?? "",
+      tipo: filter.tipo ?? "",
+      from: filter.from ?? "",
+      to: filter.to ?? "",
+    },
+    userId
+  );
+
+  return withClient(async (client) => {
+    const result = await client.query(
+      `SELECT * FROM finance_entries
+         ${whereStatement}
+         ORDER BY fecha DESC`,
+      params
+    );
+    return result.rows as Entry[];
+  });
+}
+
+export async function insertEntry(
+  data: EntryInput,
+  userId: string
+): Promise<string> {
+  const entryId = uuidv4();
+  await withClient(async (client) => {
+    await client.sql`
+      INSERT INTO finance_entries (
+        id, fecha, tipo, accion, que, plataforma_pago, cantidad,
+        detalle1, detalle2, quien, user_id
+      ) VALUES (
+        ${entryId},
+        ${data.fecha}::timestamptz,
+        ${data.tipo},
+        ${data.accion},
+        ${data.que},
+        ${data.plataforma_pago},
+        ${data.cantidad},
+        ${data.detalle1 || null},
+        ${data.detalle2 || null},
+        ${data.quien || "Yo"},
+        ${userId}
+      )
+    `;
+  });
+  return entryId;
+}
+
+export async function updateEntryById(
+  entryId: string,
+  data: EntryInput,
+  userId: string
+): Promise<void> {
+  await withClient(async (client) => {
+    await client.sql`
+      UPDATE finance_entries
+         SET fecha           = ${data.fecha}::timestamptz,
+             tipo            = ${data.tipo},
+             accion          = ${data.accion},
+             que             = ${data.que},
+             plataforma_pago = ${data.plataforma_pago},
+             cantidad        = ${data.cantidad},
+             detalle1        = ${data.detalle1 || null},
+             detalle2        = ${data.detalle2 || null},
+             quien           = ${data.quien || "Yo"},
+             updated_at      = NOW()
+       WHERE id = ${entryId}
+         AND user_id = ${userId}
+    `;
+  });
+}
+
+export async function deleteEntryById(
+  entryId: string,
+  userId: string
+): Promise<void> {
+  await withClient(async (client) => {
+    await client.sql`
+      DELETE FROM finance_entries
+       WHERE id = ${entryId}
+         AND user_id = ${userId}
+    `;
+  });
+}
+
+export async function deleteEntriesByIds(
+  ids: string[],
+  userId: string
+): Promise<void> {
+  if (ids.length === 0) return;
+  await withClient(async (client) => {
+    await client.query(
+      `DELETE FROM finance_entries
+        WHERE user_id = $1
+          AND id = ANY($2::uuid[])`,
+      [userId, ids]
+    );
+  });
+}

--- a/lib/server-data.ts
+++ b/lib/server-data.ts
@@ -4,176 +4,167 @@ import { Session } from "next-auth";
 
 /**
  * Server-side function to get summary statistics
- * This is used by server components
+ * This is used by server components.
+ *
+ * SECURITY: this function previously interpolated `month` and
+ * `session.user.id` directly into SQL strings, which was a classic
+ * SQL-injection vector. All user-controlled values are now bound through
+ * parameterized queries, and the `showAll` flag is reduced to a numeric
+ * LIMIT bound as a parameter.
  */
 export async function getSummaryStats(
   month?: string,
   session: Session | null = null,
   request?: Request
 ) {
+  if (!session?.user?.id) {
+    // Authentication is enforced at the API route layer, but we add a
+    // defensive guard here so this server-side helper can never produce
+    // cross-user totals if it's invoked without a session by mistake.
+    throw new Error("Not authenticated");
+  }
+
+  const userId = session.user.id;
+  const showAll = request
+    ? new URL(request.url).searchParams.get("showAll") === "true"
+    : false;
+  const breakdownLimit = showAll ? 1000 : 5;
+
+  const pool = createPool();
+
   try {
-    const pool = createPool();
+    // Build a reusable parameterized WHERE clause. $1 = user_id, $2 = month
+    // (nullable). When month is omitted, the date predicate is no-op.
+    const whereSql = `
+      WHERE user_id = $1
+        AND ($2::text IS NULL
+             OR date_trunc('month', fecha) =
+                date_trunc('month', $2::date))
+    `;
+    const baseParams = [userId, month ?? null];
 
-    try {
-      // Build WHERE clause for month filtering
-      let whereClause = "";
-      if (month) {
-        whereClause = `WHERE date_trunc('month', fecha) = date_trunc('month', '${month}'::date)`;
-      }
+    const incomeResult = await pool.query(
+      `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Ingreso'`,
+      baseParams
+    );
 
-      // Add user_id filter if session exists
-      if (session?.user?.id) {
-        whereClause += whereClause ? " AND " : "WHERE ";
-        whereClause += `user_id = '${session.user.id}'`;
-      }
+    const expenseResult = await pool.query(
+      `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Gasto'`,
+      baseParams
+    );
 
-      // Get income stats
-      const incomeResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        ${whereClause}
-        AND accion = 'Ingreso'
-      `);
+    const investmentResult = await pool.query(
+      `SELECT COALESCE(SUM(cantidad), 0) AS total, COUNT(*) AS count
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Inversión'`,
+      baseParams
+    );
 
-      // Get expense stats
-      const expenseResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        ${whereClause}
-        AND accion = 'Gasto'
-      `);
-
-      // Get investment stats
-      const investmentResult = await pool.query(`
-        SELECT 
-          COALESCE(SUM(cantidad), 0) as total,
-          COUNT(*) as count
-        FROM finance_entries 
-        ${whereClause}
-        AND accion = 'Inversión'
-      `);
-
-      // Get monthly trends (last 6 months)
-      const trendsResult = await pool.query(
-        `
-        SELECT 
-          date_trunc('month', fecha) as month,
-          SUM(CASE WHEN accion = 'Ingreso' THEN cantidad ELSE 0 END) as income,
-          SUM(CASE WHEN accion = 'Gasto' THEN cantidad ELSE 0 END) as expenses,
-          SUM(CASE WHEN accion = 'Inversión' THEN cantidad ELSE 0 END) as investments
-        FROM finance_entries
-        WHERE fecha >= NOW() - INTERVAL '6 months' AND user_id = $1
+    const trendsResult = await pool.query(
+      `SELECT date_trunc('month', fecha) AS month,
+              SUM(CASE WHEN accion = 'Ingreso' THEN cantidad ELSE 0 END) AS income,
+              SUM(CASE WHEN accion = 'Gasto'   THEN cantidad ELSE 0 END) AS expenses,
+              SUM(CASE WHEN accion = 'Inversión' THEN cantidad ELSE 0 END) AS investments
+         FROM finance_entries
+        WHERE fecha >= NOW() - INTERVAL '6 months'
+          AND user_id = $1
         GROUP BY date_trunc('month', fecha)
         ORDER BY month DESC
-        LIMIT 6
-      `,
-        [session?.user?.id]
-      );
+        LIMIT 6`,
+      [userId]
+    );
 
-      const monthlyTrends = trendsResult.rows.map((row) => ({
-        month: row.month.toISOString().split("T")[0],
-        income: Number(row.income),
-        expenses: Number(row.expenses),
-        investments: Number(row.investments),
-      }));
+    const monthlyTrends = trendsResult.rows.map((row) => ({
+      month: row.month.toISOString().split("T")[0],
+      income: Number(row.income),
+      expenses: Number(row.expenses),
+      investments: Number(row.investments),
+    }));
 
-      // Get expense categories (with limit based on showAll parameter)
-      const url = request ? new URL(request.url) : null;
-      const showAll = url ? url.searchParams.get("showAll") === "true" : false;
-      const expenseCategories = await pool.query(`
-        SELECT 
-          que as category,
-          SUM(cantidad) as total
-        FROM finance_entries
-        ${whereClause}
-        AND accion = 'Gasto'
+    const expenseCategories = await pool.query(
+      `SELECT que AS category, SUM(cantidad) AS total
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Gasto'
         GROUP BY que
         ORDER BY total DESC
-        ${showAll ? "" : "LIMIT 5"}
-      `);
+        LIMIT $3`,
+      [...baseParams, breakdownLimit]
+    );
 
-      // Get income categories (with limit based on showAll parameter)
-      const incomeCategories = await pool.query(`
-        SELECT 
-          que as category,
-          SUM(cantidad) as total
-        FROM finance_entries
-        ${whereClause}
-        AND accion = 'Ingreso'
+    const incomeCategories = await pool.query(
+      `SELECT que AS category, SUM(cantidad) AS total
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Ingreso'
         GROUP BY que
         ORDER BY total DESC
-        ${showAll ? "" : "LIMIT 5"}
-      `);
+        LIMIT $3`,
+      [...baseParams, breakdownLimit]
+    );
 
-      // Get investment performance
-      const investmentPerformance = await pool.query(`
-        SELECT 
-          que as investment,
-          SUM(cantidad) as total
-        FROM finance_entries
-        ${whereClause}
-        AND accion = 'Inversión'
+    const investmentPerformance = await pool.query(
+      `SELECT que AS investment, SUM(cantidad) AS total
+         FROM finance_entries
+         ${whereSql}
+          AND accion = 'Inversión'
         GROUP BY que
         ORDER BY total DESC
-        LIMIT 5
-      `);
+        LIMIT 5`,
+      baseParams
+    );
 
-      // Calculate savings rate
-      const totalIncome = Number(incomeResult.rows[0].total);
-      const totalExpenses = Number(expenseResult.rows[0].total);
-      const savingsRate =
-        totalIncome > 0
-          ? ((totalIncome - totalExpenses) / totalIncome) * 100
-          : 0;
+    const totalIncome = Number(incomeResult.rows[0].total);
+    const totalExpenses = Number(expenseResult.rows[0].total);
+    const savingsRate =
+      totalIncome > 0
+        ? ((totalIncome - totalExpenses) / totalIncome) * 100
+        : 0;
 
-      return {
-        totalIncome,
-        incomeCount: Number(incomeResult.rows[0].count),
-        totalExpense: totalExpenses,
-        expenseCount: Number(expenseResult.rows[0].count),
-        totalInvestment: Number(investmentResult.rows[0].total),
-        investmentCount: Number(investmentResult.rows[0].count),
-        balance: totalIncome - totalExpenses,
-        monthlyTrends,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        topCategories: expenseCategories.rows.map((row: any) => ({
-          category: row.category,
+    return {
+      totalIncome,
+      incomeCount: Number(incomeResult.rows[0].count),
+      totalExpense: totalExpenses,
+      expenseCount: Number(expenseResult.rows[0].count),
+      totalInvestment: Number(investmentResult.rows[0].total),
+      investmentCount: Number(investmentResult.rows[0].count),
+      balance: totalIncome - totalExpenses,
+      monthlyTrends,
+      topCategories: expenseCategories.rows.map((row) => ({
+        category: row.category as string,
+        total: Number(row.total),
+      })),
+      investmentPerformance: investmentPerformance.rows.map((row) => ({
+        investment: row.investment as string,
+        total: Number(row.total),
+      })),
+      savingsRate,
+      expenseBreakdown: {
+        total: totalExpenses,
+        categories: expenseCategories.rows.map((row) => ({
+          category: row.category as string,
           total: Number(row.total),
         })),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        investmentPerformance: investmentPerformance.rows.map((row: any) => ({
-          investment: row.investment,
+        averageMonthly: totalExpenses / 12,
+        hasMore: !showAll && expenseCategories.rows.length >= 5,
+      },
+      incomeBreakdown: {
+        total: totalIncome,
+        categories: incomeCategories.rows.map((row) => ({
+          category: row.category as string,
           total: Number(row.total),
         })),
-        savingsRate: savingsRate,
-        expenseBreakdown: {
-          total: totalExpenses,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          categories: expenseCategories.rows.map((row: any) => ({
-            category: row.category,
-            total: Number(row.total),
-          })),
-          averageMonthly: totalExpenses / 12,
-          hasMore: !showAll && expenseCategories.rows.length >= 5,
-        },
-        incomeBreakdown: {
-          total: totalIncome,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          categories: incomeCategories.rows.map((row: any) => ({
-            category: row.category,
-            total: Number(row.total),
-          })),
-          averageMonthly: totalIncome / 12,
-          hasMore: !showAll && incomeCategories.rows.length >= 5,
-        },
-      };
-    } finally {
-      await pool.end();
-    }
+        averageMonthly: totalIncome / 12,
+        hasMore: !showAll && incomeCategories.rows.length >= 5,
+      },
+    };
   } catch (error) {
     console.error("Database Error:", error);
     return {
@@ -194,128 +185,116 @@ export async function getSummaryStats(
         averageMonthly: 0,
       },
     };
+  } finally {
+    await pool.end();
   }
 }
 
 /**
- * Server-side function to get a single entry by ID
+ * Server-side function to get a single entry by ID.
+ *
+ * SECURITY: previously concatenated `session.user.id` into the query
+ * string, which would have allowed SQL injection if the session id were
+ * ever attacker-controlled. Both id and user id are now bound parameters.
  */
 export async function getEntryById(
   id: string,
   session: Session | null = null
 ): Promise<Entry | null> {
+  const pool = createPool();
+
   try {
-    const pool = createPool();
-
-    try {
-      const result = await pool.query(
-        `
-        SELECT 
-          id, 
-          fecha, 
-          accion,
-          tipo,
-          que,
-          plataforma_pago,
-          cantidad,
-          detalle1,
-          detalle2,
-          quien
-        FROM finance_entries
-        WHERE id = $1
-        ${session?.user?.id ? " AND user_id = '" + session.user.id + "'" : ""}
-      `,
-        [id]
-      );
-
-      if (result.rows.length === 0) {
-        return null;
-      }
-
-      return result.rows[0] as Entry;
-    } finally {
-      await pool.end();
+    const params: string[] = [id];
+    let userScope = "";
+    if (session?.user?.id) {
+      params.push(session.user.id);
+      userScope = " AND user_id = $2";
     }
+
+    const result = await pool.query(
+      `SELECT id, fecha, accion, tipo, que, plataforma_pago, cantidad,
+              detalle1, detalle2, quien
+         FROM finance_entries
+        WHERE id = $1${userScope}
+        LIMIT 1`,
+      params
+    );
+
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return result.rows[0] as Entry;
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to fetch entry.");
+  } finally {
+    await pool.end();
   }
 }
 
 /**
- * Server-side function to get distinct options for form dropdowns
- * Returns options ordered by frequency of use for each field
+ * Server-side function to get distinct options for form dropdowns.
+ * Returns options ordered by frequency of use for each field.
  */
 export async function getFormOptions(session: Session | null = null) {
   if (!session?.user?.id) {
     throw new Error("Not authenticated");
   }
 
-  try {
-    const pool = createPool();
+  const pool = createPool();
 
-    try {
-      // Get distinct values for each field, ordered by frequency of use
-      const [tipoResult, queResult, plataformaResult, quienResult] = await Promise.all([
+  try {
+    const [tipoResult, queResult, plataformaResult, quienResult] =
+      await Promise.all([
         pool.query(
-          `
-          SELECT tipo as value, COUNT(*) as count
-          FROM finance_entries
-          WHERE user_id = $1 AND tipo IS NOT NULL AND tipo != ''
-          GROUP BY tipo
-          ORDER BY count DESC, tipo ASC
-        `,
+          `SELECT tipo AS value, COUNT(*) AS count
+             FROM finance_entries
+            WHERE user_id = $1 AND tipo IS NOT NULL AND tipo != ''
+            GROUP BY tipo
+            ORDER BY count DESC, tipo ASC`,
           [session.user.id]
         ),
         pool.query(
-          `
-          SELECT que as value, COUNT(*) as count
-          FROM finance_entries
-          WHERE user_id = $1 AND que IS NOT NULL AND que != ''
-          GROUP BY que
-          ORDER BY count DESC, que ASC
-        `,
+          `SELECT que AS value, COUNT(*) AS count
+             FROM finance_entries
+            WHERE user_id = $1 AND que IS NOT NULL AND que != ''
+            GROUP BY que
+            ORDER BY count DESC, que ASC`,
           [session.user.id]
         ),
         pool.query(
-          `
-          SELECT plataforma_pago as value, COUNT(*) as count
-          FROM finance_entries
-          WHERE user_id = $1 AND plataforma_pago IS NOT NULL AND plataforma_pago != ''
-          GROUP BY plataforma_pago
-          ORDER BY count DESC, plataforma_pago ASC
-        `,
+          `SELECT plataforma_pago AS value, COUNT(*) AS count
+             FROM finance_entries
+            WHERE user_id = $1
+              AND plataforma_pago IS NOT NULL
+              AND plataforma_pago != ''
+            GROUP BY plataforma_pago
+            ORDER BY count DESC, plataforma_pago ASC`,
           [session.user.id]
         ),
         pool.query(
-          `
-          SELECT quien as value, COUNT(*) as count
-          FROM finance_entries
-          WHERE user_id = $1 AND quien IS NOT NULL AND quien != ''
-          GROUP BY quien
-          ORDER BY count DESC, quien ASC
-        `,
+          `SELECT quien AS value, COUNT(*) AS count
+             FROM finance_entries
+            WHERE user_id = $1 AND quien IS NOT NULL AND quien != ''
+            GROUP BY quien
+            ORDER BY count DESC, quien ASC`,
           [session.user.id]
         ),
       ]);
 
-      // Extract just the values, ordered by frequency
-      const tipo = tipoResult.rows.map((row) => row.value);
-      const que = queResult.rows.map((row) => row.value);
-      const plataforma_pago = plataformaResult.rows.map((row) => row.value);
-      const quien = quienResult.rows.map((row) => row.value);
-
-      return {
-        tipo,
-        que,
-        plataforma_pago,
-        quien,
-      };
-    } finally {
-      await pool.end();
-    }
+    return {
+      tipo: tipoResult.rows.map((row) => row.value as string),
+      que: queResult.rows.map((row) => row.value as string),
+      plataforma_pago: plataformaResult.rows.map(
+        (row) => row.value as string
+      ),
+      quien: quienResult.rows.map((row) => row.value as string),
+    };
   } catch (error) {
     console.error("Database Error:", error);
     throw new Error("Failed to fetch form options.");
+  } finally {
+    await pool.end();
   }
 }

--- a/lib/users/repo.ts
+++ b/lib/users/repo.ts
@@ -1,0 +1,40 @@
+import { v4 as uuidv4 } from "uuid";
+import { withClient } from "@/lib/db";
+
+export interface UserRecord {
+  id: string;
+  name: string | null;
+  email: string | null;
+}
+
+/**
+ * Insert a new user. Returns the generated id.
+ *
+ * Caller responsibility: ensure the email/name pair is allowlisted (the
+ * NextAuth signIn callback handles this for the OAuth flow).
+ */
+export async function insertUser(formData: {
+  name: string;
+  email: string;
+}): Promise<string> {
+  const id = uuidv4();
+  await withClient(async (client) => {
+    await client.sql`
+      INSERT INTO users (id, name, email)
+      VALUES (${id}, ${formData.name}, ${formData.email})
+    `;
+  });
+  return id;
+}
+
+export async function findUserByEmail(email: string): Promise<UserRecord | null> {
+  return withClient(async (client) => {
+    const result = await client.sql`
+      SELECT id, name, email
+        FROM users
+       WHERE email = ${email}
+       LIMIT 1
+    `;
+    return (result.rows[0] as UserRecord | undefined) ?? null;
+  });
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,6 +37,19 @@ export function formatCurrency(amount: number) {
 }
 
 /**
+ * Escape `%`, `_` and `\` so a user-supplied string can be safely embedded
+ * in a SQL LIKE / ILIKE pattern. Without escaping, end users (or the
+ * public API) can inject wildcards that force expensive scans or bypass
+ * obvious matching semantics.
+ *
+ * Use together with the standard `ILIKE $1` parameterized binding, e.g.
+ *   `params.push("%" + escapeLikePattern(search) + "%")`.
+ */
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
  * Checks if a transaction should be split (joyntlanda logic)
  * Returns true if the transaction is a 'Gasto' and either:
  * - plataforma_pago equals 'joyntlanda' (case-insensitive)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,14 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // NOTE: Do NOT add server-only secrets here.
+  // Anything declared under `env` is inlined into the client bundle at build
+  // time and becomes publicly visible. Only safe public values may live here,
+  // and even those should normally use the `NEXT_PUBLIC_` convention so they
+  // are surfaced through `process.env.NEXT_PUBLIC_*` automatically.
   env: {
-    POSTGRES_URL: process.env.POSTGRES_URL,
     NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
-    DATABASE_URL: process.env.DATABASE_URL,
-    GITHUB_ID: process.env.GITHUB_ID,
-    GITHUB_SECRET: process.env.GITHUB_SECRET,
-    ALLOWED_USERS: process.env.ALLOWED_USERS,
   },
   typescript: {
+    // TODO(security): a number of pre-existing type errors live in
+    // components/finance-form.tsx, components/ui/calendar.tsx, and
+    // components/monthly-trends-chart.tsx. They are tracked separately
+    // and need to be fixed so this flag can flip to false. Until then,
+    // CI must still run `pnpm exec tsc --noEmit` so the errors don't
+    // grow silently — see the verification step in CONTRIBUTING.
     ignoreBuildErrors: true,
   },
   images: {
@@ -18,7 +24,7 @@ const nextConfig = {
     webpackBuildWorker: true,
     parallelServerBuildTraces: true,
     parallelServerCompiles: true,
-  }
-}
+  },
+};
 
-export default nextConfig
+export default nextConfig;


### PR DESCRIPTION
## Summary

This branch addresses three distinct concerns that were bundled together:

### Security fixes (critical)
- **SQL injection**: All user-supplied values in `server-data.ts`, `analytics/route.ts`, `entries/[id]/route.ts`, and `stats/route.ts` are now bound via parameterized queries. Previously, `session.user.id`, `month`, and path params were interpolated directly into SQL strings.
- **LIKE wildcard injection**: Search terms in `actions.ts` and `analytics/route.ts` now escape `%`, `_`, and `\` before embedding in `ILIKE` patterns. The shared `escapeLikePattern()` utility in `lib/utils.ts` is used everywhere.
- **Auth bypass (empty ALLOWED_USERS)**: The old code split `ALLOWED_USERS` on `,`, which produced `[""]` for an empty/missing value. Since the default `profile.login` was `""`, anyone could sign in. `isAllowed()` now treats empty/missing as a hard deny.
- **IDOR on `/api/entries/[id]`**: The route previously loaded any entry by ID with no ownership check. Now scoped to `user_id`.
- **Unauthenticated `/api/stats`**: This endpoint ran un-scoped aggregations across the entire table, leaking every user's totals. Now requires a session and scopes to the authenticated user.
- **Config leak**: `DATABASE_URL`, `POSTGRES_URL`, `GITHUB_ID`, `GITHUB_SECRET`, and `ALLOWED_USERS` were in `next.config.mjs` `env`, which Next.js inlines into the client bundle. Removed all secrets; only `NEXT_PUBLIC_APP_NAME` remains.
- **Dev credentials in source**: Hard-coded dev credentials in the auth route were moved to the `DEV_CREDENTIALS` env var. The Credentials provider is now gated to `NODE_ENV !== 'production'` and requires the env var to be set. Password comparison is timing-safe.
- **API key hashing**: Plain SHA-256 replaced with HMAC-SHA-256 keyed by `API_KEY_PEPPER`. Legacy SHA-256 hashes still verify for rollout. Key comparison uses `timingSafeEqual`. Key entropy doubled from 24 to 32 random bytes.
- **Prompt size caps**: AI routes (`/api/ai/chat`, `parse-entry`, `parse-for-form`) now cap message count (50) and total text size (32KB / 4KB) to prevent prompt-bombing DoS and token-cost attacks.

### Analytics feature expansion
- 14 new analytics components: seasonal explorer, tipo explorer, trend explorer, spending velocity, category deep-dive, intelligence explorer, etc.
- `analytics/route.ts` now returns platform breakdowns, type breakdowns, tipo-que cross-tabs, top transactions, category-platform cross-tabs, per-category stats, and temporal per-type data.
- Hierarchical tipo-que cascading filter in the analytics filter bar.

### Module refactoring
- `lib/actions.ts` (415 lines) extracted into `lib/entries/repo.ts`, `lib/users/repo.ts`, `lib/db.ts`. Original file is now a thin re-export facade.
- `lib/cryptoActions.ts` (592 lines) extracted into `lib/crypto/transactions.ts`, `lib/crypto/wallets.ts`, `lib/crypto/holdings.ts`, `lib/crypto/mappers.ts`. Original file re-exports the same public API.
- `lib/auth/allowlist.ts` and `lib/auth/server.ts` extracted for testability of the `isAllowed()` function.
- `lib/server-data.ts` cleaned up: parameterized all queries, added auth guards, fixed pool lifecycle (try/finally).

### Regression tests added
- `escapeLikePattern` utility (7 cases covering %, _, \, combined, empty, injection)
- API key HMAC hashing (with/without pepper, key format, uniqueness, prefix rejection)
- ALLOWED_USERS allowlist contract (10 cases including the empty-string bypass)

## How to test
- `pnpm test -- __tests__/lib/` runs all 63 lib tests
- Manual: sign in with a user not in `ALLOWED_USERS` and verify the redirect to `/auth/unauthorized`
- Manual: create an API key, then set `API_KEY_PEPPER` and verify the key still works (legacy fallback)

## Breaking changes
- `DEV_CREDENTIALS` env var is now required for dev login (was hard-coded)
- `API_KEY_PEPPER` env var recommended; without it, keys fall back to SHA-256 (with a console warning)
- Any client hitting `/api/stats` without auth will now get 401
- `/api/entries/[id]` now returns 404 for entries not owned by the session user