### PR TITLE
fix: local dev tooling -- githooks, editorconfig, prettier config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npx --no lint-staged
+npx lint-staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["editorconfig.editorconfig"]
+}


### PR DESCRIPTION
## Summary

Fixes local development tooling gaps: broken pre-commit hook, missing editorconfig, and verifies prettier configuration.

Closes #16, #18, #25

## Changes

### Issue #16 -- Missing git hooks (`npx --no` bug)
- Fixed `.githooks/pre-commit`: removed erroneous `--no` flag (`npx --no lint-staged` → `npx lint-staged`)
- Verified `.githooks/pre-push` is correct (`pnpm run typecheck && pnpm test`)
- Confirmed both hooks are executable

### Issue #18 -- No Prettier config file
- Verified that `prettier.config.mjs` already exists with correct values (`singleQuote: true`, `printWidth: 80`, `trailingComma: "all"`, `semi: true`, `tabWidth: 2`)
- Confirmed `pnpm format:check` passes -- no additional `.prettierrc` needed
- **No code changes required**; issue was already resolved by existing config

### Issue #25 -- No .editorconfig
- Created `.editorconfig` with standard settings (2-space indent, LF line endings, UTF-8 charset, trim trailing whitespace)
- Created `.vscode/extensions.json` recommending the EditorConfig extension

## Test plan
- [x] `pnpm format:check` passes
- [ ] Pre-commit hook triggers lint-staged on commit
- [ ] Pre-push hook runs typecheck + test on push