### PR TITLE
fix: add auth enforcement, security headers, error boundary, and Suspense boundaries

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,317 +1,35 @@
-// app/analytics/page.tsx
-'use client';
+import { Suspense } from 'react';
+import AnalyticsPageContent from '@/components/analytics-page-content';
 
-import { useMemo } from 'react';
-import { AnalyticsFilter } from '@/components/analytics-filter';
-import { useAnalyticsData, type Filters } from '@/hooks/use-analytics-data';
-import {
-  getTemporalChartData,
-  getCategoryChartData,
-  getTemporalChartOptions,
-  getLineChartOptions,
-  getDoughnutChartOptions,
-  getPlatformChartData,
-  getPlatformChartOptions,
-  getTypeChartData,
-  getTypeChartOptions,
-  getCategoryPlatformBreakdown,
-  getCategoryPlatformChartOptions,
-  getCategoryTrendData,
-  computeSpendingVelocity,
-  computeTipoSpendingVelocity,
-  getSeasonalChartData,
-  getSeasonalChartOptions,
-  getTipoExplorerData,
-  getTipoExplorerChartOptions,
-  getTipoTrendData,
-} from '@/lib/analytics-charts';
-import { SummaryCards } from '@/components/analytics/SummaryCards';
-import { PerActionCards } from '@/components/analytics/PerActionCards';
-import { TemporalChart } from '@/components/analytics/TemporalChart';
-import { NetTrendChart } from '@/components/analytics/NetTrendChart';
-import { CategoryChart } from '@/components/analytics/CategoryChart';
-import { PlatformChart } from '@/components/analytics/PlatformChart';
-import { TypeChart } from '@/components/analytics/TypeChart';
-import { CategoryDeepDive } from '@/components/analytics/CategoryDeepDive';
-import { TopTransactionsTable } from '@/components/analytics/TopTransactionsTable';
-import { SavingsRateCard } from '@/components/analytics/SavingsRateCard';
-import { TipoExplorer } from '@/components/analytics/TipoExplorer';
-import { TrendExplorer } from '@/components/analytics/TrendExplorer';
-import { SpendingVelocity } from '@/components/analytics/SpendingVelocity';
-import { IntelligenceExplorer } from '@/components/analytics/IntelligenceExplorer';
-import { SeasonalExplorer } from '@/components/analytics/SeasonalExplorer';
+export const dynamic = 'force-dynamic';
 
-export default function AnalyticsPage() {
-  const { data, filters, setFilters, loading } = useAnalyticsData();
-  const temporalChartData = getTemporalChartData(
-    data,
-    data.metrics?.groupBy || 'month',
-  );
-  const categoryChartData = getCategoryChartData(data);
-  const platformChartData = getPlatformChartData(data.platformData);
-  const typeChartData = getTypeChartData(data.typeData);
-
-  // Build tipo → que mapping for cascading filters
-  const tipoToQueMap = useMemo(() => {
-    const map = new Map<string, Set<string>>();
-    for (const item of data.tipoQueData) {
-      if (!map.has(item.type)) map.set(item.type, new Set());
-      map.get(item.type)!.add(item.category);
-    }
-    return map;
-  }, [data.tipoQueData]);
-
-  // Compute income - expenses (excluding investments) per period ("balance")
-  const netIncomeExpenseLabels = Array.from(
-    new Set(data.temporalData.map((item) => item.period)),
-  ).sort();
-  const balance = netIncomeExpenseLabels.map((period) => {
-    const ingresos = data.temporalData
-      .filter((item) => item.period === period && item.action === 'Ingreso')
-      .reduce((sum, item) => sum + Number(item.total || 0), 0);
-    const gastos = data.temporalData
-      .filter((item) => item.period === period && item.action === 'Gasto')
-      .reduce((sum, item) => sum + Number(item.total || 0), 0);
-    return ingresos - Math.abs(gastos);
-  });
-  const accBalance = balance.reduce((acc: number[], curr) => {
-    if (acc.length === 0) return [curr];
-    acc.push(acc[acc.length - 1] + curr);
-    return acc;
-  }, []);
-
-  const monthsInRange = (() => {
-    const msPerDay = 24 * 60 * 60 * 1000;
-    let start: Date | undefined;
-    let end: Date | undefined;
-    if (filters.from && filters.to) {
-      start = new Date(filters.from);
-      end = new Date(filters.to);
-    } else if ((data.temporalData || []).length > 0) {
-      const periods = (data.temporalData || []).map((t) => new Date(t.period));
-      start = new Date(Math.min(...periods.map((p) => p.getTime())));
-      end = new Date(Math.max(...periods.map((p) => p.getTime())));
-    }
-    if (!start || !end) return 0;
-    const startMs = new Date(
-      start.getFullYear(),
-      start.getMonth(),
-      start.getDate(),
-      0,
-      0,
-      0,
-      0,
-    ).getTime();
-    const endMs = new Date(
-      end.getFullYear(),
-      end.getMonth(),
-      end.getDate(),
-      23,
-      59,
-      59,
-      999,
-    ).getTime();
-    const days = Math.max(0, (endMs - startMs) / msPerDay);
-    return days / 30;
-  })();
-  const yearsInRange = monthsInRange / 12;
-
-  // Compute velocities
-  const queVelocities = computeSpendingVelocity(
-    data.categoryTemporalData,
-    'Gasto',
-  );
-  const tipoVelocities = computeTipoSpendingVelocity(
-    data.typeTemporalData,
-    'Gasto',
-  );
-
-  // Types with temporal data
-  const typesWithTemporal = Array.from(
-    new Set(data.typeTemporalData.map((d) => d.type)),
-  ).sort();
-
+export default async function AnalyticsPage() {
   return (
-    <div className="container mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-6">Analíticas Financieras</h1>
-      <div className="mb-6">
-        <AnalyticsFilter
-          value={filters}
-          onChange={(f) => setFilters(f as Filters)}
-          actions={[...new Set(data.temporalData.map((d) => d.action))]}
-          categories={[...new Set(data.categoryData.map((d) => d.category))]}
-          platforms={[
-            ...new Set([
-              ...data.temporalData.map((d) => d.platform).filter(Boolean),
-              ...data.categoryData.map((d) => d.platform).filter(Boolean),
-              ...data.platformData.map((d) => d.platform).filter(Boolean),
-            ]),
-          ]}
-          types={[
-            ...new Set([
-              ...data.temporalData.map((d) => d.type).filter(Boolean),
-              ...data.categoryData.map((d) => d.type).filter(Boolean),
-              ...data.typeData.map((d) => d.type).filter(Boolean),
-              ...data.tipoQueData.map((d) => d.type).filter(Boolean),
-              ...data.typeTemporalData.map((d) => d.type).filter(Boolean),
-            ]),
-          ]}
-          years={[2025, 2024, 2023]}
-          tipoToQueMap={tipoToQueMap}
-        />
-      </div>
-
-      <SummaryCards
-        sums={data.sums}
-        metrics={data.metrics as Parameters<typeof SummaryCards>[0]['metrics']}
-        monthsInRange={monthsInRange}
-        yearsInRange={yearsInRange}
-      />
-      <PerActionCards
-        metrics={
-          data.metrics as Parameters<typeof PerActionCards>[0]['metrics']
-        }
-      />
-      <div className="mb-6 max-w-sm">
-        <SavingsRateCard
-          income={data.sums.ingresos}
-          expenses={data.sums.gastos}
-        />
-      </div>
-
-      {/* ─── OVERVIEW CHARTS ─── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <TemporalChart
-          data={temporalChartData}
-          options={getTemporalChartOptions(data.temporalData)}
-          loading={loading}
-        />
-        <NetTrendChart
-          data={{
-            labels: netIncomeExpenseLabels.map((p) => {
-              const d = new Date(p);
-              return data.metrics?.groupBy === 'year'
-                ? d.getFullYear().toString()
-                : d.toLocaleString('es-ES', {
-                    month: 'short',
-                    year: 'numeric',
-                  });
-            }),
-            datasets: [
-              {
-                label: 'Neto',
-                data: (data.netTemporal || []).map((n) => n.net),
-                borderColor: 'rgba(99, 102, 241, 1)',
-                backgroundColor: 'rgba(99, 102, 241, 0.2)',
-              },
-              {
-                label: 'Balance',
-                data: balance,
-                borderColor: 'rgba(34,197,94,1)',
-                backgroundColor: 'rgba(34,197,94,0.1)',
-                borderDash: [6, 3],
-              },
-              {
-                label: 'Acc Balance',
-                data: accBalance,
-                borderColor: 'rgba(234,179,8,1)',
-                backgroundColor: 'rgba(234,179,8,0.1)',
-                borderDash: [2, 2],
-              },
-            ],
-          }}
-          options={getLineChartOptions()}
-          loading={loading}
-        />
-        <CategoryChart
-          data={categoryChartData}
-          options={getDoughnutChartOptions(
-            categoryChartData.total,
-            data.categoryData,
-          )}
-          loading={loading}
-        />
-        <PlatformChart
-          data={platformChartData}
-          options={getPlatformChartOptions()}
-          loading={loading}
-        />
-      </div>
-
-      {/* ─── BREAKDOWN CHARTS ─── */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <TypeChart
-          data={typeChartData}
-          options={getTypeChartOptions()}
-          loading={loading}
-        />
-        <CategoryDeepDive
-          categoryData={data.categoryData}
-          categoryPlatformData={data.categoryPlatformData}
-          getChartData={getCategoryPlatformBreakdown}
-          getChartOptions={getCategoryPlatformChartOptions}
-          loading={loading}
-        />
-      </div>
-
-      {/* ─── TIPO EXPLORER ─── */}
-      <div className="mb-6">
-        <TipoExplorer
-          tipoQueData={data.tipoQueData}
-          types={typesWithTemporal}
-          getChartData={getTipoExplorerData}
-          getChartOptions={getTipoExplorerChartOptions}
-          loading={loading}
-        />
-      </div>
-
-      {/* ─── DEEP INSIGHTS ─── */}
-      <div className="grid grid-cols-1 gap-6 mb-6">
-        <TrendExplorer
-          categoryTemporalData={data.categoryTemporalData}
-          typeTemporalData={data.typeTemporalData}
-          tipoQueData={data.tipoQueData}
-          types={typesWithTemporal}
-          groupBy={data.metrics?.groupBy || 'month'}
-          loading={loading}
-          getCategoryTrendData={getCategoryTrendData}
-          getTipoTrendData={getTipoTrendData}
-          getLineChartOptions={getLineChartOptions}
-        />
-        <SpendingVelocity
-          velocities={queVelocities}
-          loading={loading}
-          title="Velocidad por Categoría"
-        />
-        <SpendingVelocity
-          velocities={tipoVelocities}
-          loading={loading}
-          title="Velocidad por Tipo"
-        />
-        <IntelligenceExplorer
-          categoryStats={data.categoryStats}
-          categoryPlatformData={data.categoryPlatformData}
-          categoryData={data.categoryData}
-          temporalData={data.temporalData}
-          types={typesWithTemporal}
-          loading={loading}
-        />
-        <SeasonalExplorer
-          categoryTemporalData={data.categoryTemporalData}
-          types={typesWithTemporal}
-          getChartData={getSeasonalChartData}
-          getChartOptions={getSeasonalChartOptions}
-          loading={loading}
-        />
-      </div>
-
-      {/* ─── TOP TRANSACTIONS ─── */}
-      <div className="grid grid-cols-1 gap-6">
-        <TopTransactionsTable
-          transactions={data.topTransactions}
-          loading={loading}
-        />
-      </div>
-    </div>
+    <Suspense
+      fallback={
+        <div className="container mx-auto p-4 space-y-6">
+          <div className="h-8 w-64 bg-muted animate-pulse rounded-lg mb-6" />
+          <div className="flex gap-2 mb-6">
+            <div className="h-10 w-40 bg-muted animate-pulse rounded-lg" />
+            <div className="h-10 w-40 bg-muted animate-pulse rounded-lg" />
+            <div className="h-10 w-40 bg-muted animate-pulse rounded-lg" />
+            <div className="h-10 w-32 bg-muted animate-pulse rounded-lg" />
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+          </div>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+            <div className="h-[300px] bg-muted animate-pulse rounded-lg" />
+          </div>
+          <div className="h-[400px] bg-muted animate-pulse rounded-lg" />
+        </div>
+      }
+    >
+      <AnalyticsPageContent />
+    </Suspense>
   );
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+      <h1 className="text-4xl font-bold">Something went wrong</h1>
+      <p className="text-muted-foreground text-lg">
+        An unexpected error occurred. Please try again.
+      </p>
+      <div className="flex gap-4">
+        <Button onClick={() => reset()}>Try again</Button>
+        <Button asChild variant="outline">
+          <Link href="/">Go home</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -7,6 +7,7 @@ import { TableSkeleton } from '@/components/table-skeleton';
 import { SearchFilter } from '@/components/search-filter';
 import { QuickEntryBar } from '@/components/ai/QuickEntryBar';
 import { DEFAULT_ACCION_FILTER, ITEMS_PER_PAGE } from '@/config';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,17 +60,19 @@ export default async function RecordsPage({
         </div>
       </div>
 
-      {/* AI Quick Entry - Prominent placement with card styling */}
-      <QuickEntryBar />
+      <Suspense fallback={<Skeleton className="h-24 w-full rounded-lg" />}>
+        <QuickEntryBar />
+      </Suspense>
 
-      {/* Search/Filter Section - Clear visual separation */}
       <div className="border-t pt-6">
         <div className="flex items-center gap-2 mb-4">
           <h2 className="text-lg font-semibold text-muted-foreground">
             Buscar y Filtrar
           </h2>
         </div>
-        <SearchFilter />
+        <Suspense fallback={<Skeleton className="h-10 w-full" />}>
+          <SearchFilter />
+        </Suspense>
       </div>
 
       <Suspense fallback={<TableSkeleton />}>

--- a/components/analytics-page-content.tsx
+++ b/components/analytics-page-content.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useMemo } from 'react';
+import { AnalyticsFilter } from '@/components/analytics-filter';
+import { useAnalyticsData, type Filters } from '@/hooks/use-analytics-data';
+import {
+  getTemporalChartData,
+  getCategoryChartData,
+  getTemporalChartOptions,
+  getLineChartOptions,
+  getDoughnutChartOptions,
+  getPlatformChartData,
+  getPlatformChartOptions,
+  getTypeChartData,
+  getTypeChartOptions,
+  getCategoryPlatformBreakdown,
+  getCategoryPlatformChartOptions,
+  getCategoryTrendData,
+  computeSpendingVelocity,
+  computeTipoSpendingVelocity,
+  getSeasonalChartData,
+  getSeasonalChartOptions,
+  getTipoExplorerData,
+  getTipoExplorerChartOptions,
+  getTipoTrendData,
+} from '@/lib/analytics-charts';
+import { SummaryCards } from '@/components/analytics/SummaryCards';
+import { PerActionCards } from '@/components/analytics/PerActionCards';
+import { TemporalChart } from '@/components/analytics/TemporalChart';
+import { NetTrendChart } from '@/components/analytics/NetTrendChart';
+import { CategoryChart } from '@/components/analytics/CategoryChart';
+import { PlatformChart } from '@/components/analytics/PlatformChart';
+import { TypeChart } from '@/components/analytics/TypeChart';
+import { CategoryDeepDive } from '@/components/analytics/CategoryDeepDive';
+import { TopTransactionsTable } from '@/components/analytics/TopTransactionsTable';
+import { SavingsRateCard } from '@/components/analytics/SavingsRateCard';
+import { TipoExplorer } from '@/components/analytics/TipoExplorer';
+import { TrendExplorer } from '@/components/analytics/TrendExplorer';
+import { SpendingVelocity } from '@/components/analytics/SpendingVelocity';
+import { IntelligenceExplorer } from '@/components/analytics/IntelligenceExplorer';
+import { SeasonalExplorer } from '@/components/analytics/SeasonalExplorer';
+
+export default function AnalyticsPageContent() {
+  const { data, filters, setFilters, loading } = useAnalyticsData();
+  const temporalChartData = getTemporalChartData(
+    data,
+    data.metrics?.groupBy || 'month',
+  );
+  const categoryChartData = getCategoryChartData(data);
+  const platformChartData = getPlatformChartData(data.platformData);
+  const typeChartData = getTypeChartData(data.typeData);
+
+  const tipoToQueMap = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const item of data.tipoQueData) {
+      if (!map.has(item.type)) map.set(item.type, new Set());
+      map.get(item.type)!.add(item.category);
+    }
+    return map;
+  }, [data.tipoQueData]);
+
+  const netIncomeExpenseLabels = Array.from(
+    new Set(data.temporalData.map((item) => item.period)),
+  ).sort();
+  const balance = netIncomeExpenseLabels.map((period) => {
+    const ingresos = data.temporalData
+      .filter((item) => item.period === period && item.action === 'Ingreso')
+      .reduce((sum, item) => sum + Number(item.total || 0), 0);
+    const gastos = data.temporalData
+      .filter((item) => item.period === period && item.action === 'Gasto')
+      .reduce((sum, item) => sum + Number(item.total || 0), 0);
+    return ingresos - Math.abs(gastos);
+  });
+  const accBalance = balance.reduce((acc: number[], curr) => {
+    if (acc.length === 0) return [curr];
+    acc.push(acc[acc.length - 1] + curr);
+    return acc;
+  }, []);
+
+  const monthsInRange = (() => {
+    const msPerDay = 24 * 60 * 60 * 1000;
+    let start: Date | undefined;
+    let end: Date | undefined;
+    if (filters.from && filters.to) {
+      start = new Date(filters.from);
+      end = new Date(filters.to);
+    } else if ((data.temporalData || []).length > 0) {
+      const periods = (data.temporalData || []).map((t) => new Date(t.period));
+      start = new Date(Math.min(...periods.map((p) => p.getTime())));
+      end = new Date(Math.max(...periods.map((p) => p.getTime())));
+    }
+    if (!start || !end) return 0;
+    const startMs = new Date(
+      start.getFullYear(),
+      start.getMonth(),
+      start.getDate(),
+      0,
+      0,
+      0,
+      0,
+    ).getTime();
+    const endMs = new Date(
+      end.getFullYear(),
+      end.getMonth(),
+      end.getDate(),
+      23,
+      59,
+      59,
+      999,
+    ).getTime();
+    const days = Math.max(0, (endMs - startMs) / msPerDay);
+    return days / 30;
+  })();
+  const yearsInRange = monthsInRange / 12;
+
+  const queVelocities = computeSpendingVelocity(
+    data.categoryTemporalData,
+    'Gasto',
+  );
+  const tipoVelocities = computeTipoSpendingVelocity(
+    data.typeTemporalData,
+    'Gasto',
+  );
+
+  const typesWithTemporal = Array.from(
+    new Set(data.typeTemporalData.map((d) => d.type)),
+  ).sort();
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-6">Analíticas Financieras</h1>
+      <div className="mb-6">
+        <AnalyticsFilter
+          value={filters}
+          onChange={(f) => setFilters(f as Filters)}
+          actions={[...new Set(data.temporalData.map((d) => d.action))]}
+          categories={[...new Set(data.categoryData.map((d) => d.category))]}
+          platforms={[
+            ...new Set([
+              ...data.temporalData.map((d) => d.platform).filter(Boolean),
+              ...data.categoryData.map((d) => d.platform).filter(Boolean),
+              ...data.platformData.map((d) => d.platform).filter(Boolean),
+            ]),
+          ]}
+          types={[
+            ...new Set([
+              ...data.temporalData.map((d) => d.type).filter(Boolean),
+              ...data.categoryData.map((d) => d.type).filter(Boolean),
+              ...data.typeData.map((d) => d.type).filter(Boolean),
+              ...data.tipoQueData.map((d) => d.type).filter(Boolean),
+              ...data.typeTemporalData.map((d) => d.type).filter(Boolean),
+            ]),
+          ]}
+          years={[2025, 2024, 2023]}
+          tipoToQueMap={tipoToQueMap}
+        />
+      </div>
+
+      <SummaryCards
+        sums={data.sums}
+        metrics={data.metrics as Parameters<typeof SummaryCards>[0]['metrics']}
+        monthsInRange={monthsInRange}
+        yearsInRange={yearsInRange}
+      />
+      <PerActionCards
+        metrics={
+          data.metrics as Parameters<typeof PerActionCards>[0]['metrics']
+        }
+      />
+      <div className="mb-6 max-w-sm">
+        <SavingsRateCard
+          income={data.sums.ingresos}
+          expenses={data.sums.gastos}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <TemporalChart
+          data={temporalChartData}
+          options={getTemporalChartOptions(data.temporalData)}
+          loading={loading}
+        />
+        <NetTrendChart
+          data={{
+            labels: netIncomeExpenseLabels.map((p) => {
+              const d = new Date(p);
+              return data.metrics?.groupBy === 'year'
+                ? d.getFullYear().toString()
+                : d.toLocaleString('es-ES', {
+                    month: 'short',
+                    year: 'numeric',
+                  });
+            }),
+            datasets: [
+              {
+                label: 'Neto',
+                data: (data.netTemporal || []).map((n) => n.net),
+                borderColor: 'rgba(99, 102, 241, 1)',
+                backgroundColor: 'rgba(99, 102, 241, 0.2)',
+              },
+              {
+                label: 'Balance',
+                data: balance,
+                borderColor: 'rgba(34,197,94,1)',
+                backgroundColor: 'rgba(34,197,94,0.1)',
+                borderDash: [6, 3],
+              },
+              {
+                label: 'Acc Balance',
+                data: accBalance,
+                borderColor: 'rgba(234,179,8,1)',
+                backgroundColor: 'rgba(234,179,8,0.1)',
+                borderDash: [2, 2],
+              },
+            ],
+          }}
+          options={getLineChartOptions()}
+          loading={loading}
+        />
+        <CategoryChart
+          data={categoryChartData}
+          options={getDoughnutChartOptions(
+            categoryChartData.total,
+            data.categoryData,
+          )}
+          loading={loading}
+        />
+        <PlatformChart
+          data={platformChartData}
+          options={getPlatformChartOptions()}
+          loading={loading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        <TypeChart
+          data={typeChartData}
+          options={getTypeChartOptions()}
+          loading={loading}
+        />
+        <CategoryDeepDive
+          categoryData={data.categoryData}
+          categoryPlatformData={data.categoryPlatformData}
+          getChartData={getCategoryPlatformBreakdown}
+          getChartOptions={getCategoryPlatformChartOptions}
+          loading={loading}
+        />
+      </div>
+
+      <div className="mb-6">
+        <TipoExplorer
+          tipoQueData={data.tipoQueData}
+          types={typesWithTemporal}
+          getChartData={getTipoExplorerData}
+          getChartOptions={getTipoExplorerChartOptions}
+          loading={loading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 mb-6">
+        <TrendExplorer
+          categoryTemporalData={data.categoryTemporalData}
+          typeTemporalData={data.typeTemporalData}
+          tipoQueData={data.tipoQueData}
+          types={typesWithTemporal}
+          groupBy={data.metrics?.groupBy || 'month'}
+          loading={loading}
+          getCategoryTrendData={getCategoryTrendData}
+          getTipoTrendData={getTipoTrendData}
+          getLineChartOptions={getLineChartOptions}
+        />
+        <SpendingVelocity
+          velocities={queVelocities}
+          loading={loading}
+          title="Velocidad por Categoría"
+        />
+        <SpendingVelocity
+          velocities={tipoVelocities}
+          loading={loading}
+          title="Velocidad por Tipo"
+        />
+        <IntelligenceExplorer
+          categoryStats={data.categoryStats}
+          categoryPlatformData={data.categoryPlatformData}
+          categoryData={data.categoryData}
+          temporalData={data.temporalData}
+          types={typesWithTemporal}
+          loading={loading}
+        />
+        <SeasonalExplorer
+          categoryTemporalData={data.categoryTemporalData}
+          types={typesWithTemporal}
+          getChartData={getSeasonalChartData}
+          getChartOptions={getSeasonalChartOptions}
+          loading={loading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6">
+        <TopTransactionsTable
+          transactions={data.topTransactions}
+          loading={loading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/analytics-skeleton.tsx
+++ b/components/analytics-skeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function AnalyticsSkeleton() {
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <Skeleton className="h-8 w-64 mb-6" />
+      <div className="flex gap-2 mb-6">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Skeleton className="h-[300px] rounded-lg" />
+        <Skeleton className="h-[300px] rounded-lg" />
+        <Skeleton className="h-[300px] rounded-lg" />
+        <Skeleton className="h-[300px] rounded-lg" />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Skeleton className="h-[300px] rounded-lg" />
+        <Skeleton className="h-[300px] rounded-lg" />
+      </div>
+      <Skeleton className="h-[400px] rounded-lg" />
+    </div>
+  );
+}

--- a/components/records-skeleton.tsx
+++ b/components/records-skeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function RecordsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <div className="border-t pt-6">
+        <Skeleton className="h-5 w-40 mb-4" />
+        <Skeleton className="h-10 w-full mb-4" />
+      </div>
+      <div className="rounded-md border">
+        <div className="p-4 space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,7 +2,7 @@ import { withAuth } from 'next-auth/middleware';
 import { NextResponse } from 'next/server';
 
 export default withAuth(
-  function middleware(req) {
+  function middleware(_req) {
     const response = NextResponse.next();
 
     response.headers.set('X-Frame-Options', 'DENY');

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,29 @@
+import { withAuth } from 'next-auth/middleware';
+import { NextResponse } from 'next/server';
+
+export default withAuth(
+  function middleware(req) {
+    const response = NextResponse.next();
+
+    response.headers.set('X-Frame-Options', 'DENY');
+    response.headers.set('X-Content-Type-Options', 'nosniff');
+    response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+    response.headers.set(
+      'Strict-Transport-Security',
+      'max-age=63072000; includeSubDomains; preload',
+    );
+
+    return response;
+  },
+  {
+    callbacks: {
+      authorized: ({ token }) => !!token,
+    },
+  },
+);
+
+export const config = {
+  matcher: [
+    '/((?!login|api/v1/|api/auth/|_next/static|_next/image|favicon.ico).*)',
+  ],
+};


### PR DESCRIPTION
Closes #38, #44, #46

## Changes

### Issue #38 - Auth enforcement and security headers
- Updated proxy.ts to use withAuth from next-auth/middleware with proper authorization callback
- Protected routes redirect to /login if unauthenticated
- Public routes allowed: /login, /api/v1/*, /api/auth/*, static assets
- Security headers added to all responses: X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Strict-Transport-Security

### Issue #44 - Suspense boundaries
- Refactored app/analytics/page.tsx into a server wrapper with Suspense fallback skeleton
- Extracted client component to components/analytics-page-content.tsx
- Added Suspense boundaries around QuickEntryBar and SearchFilter in app/records/page.tsx

### Issue #46 - Global error boundary
- Created app/error.tsx with Something went wrong message, Try again button, Go home link, and error logging

## Test Results
- pnpm tsc --noEmit: passed
- pnpm build: succeeded
- pnpm test: 11 suites, 80 tests passed